### PR TITLE
Add Podspec for CocoaPods building option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,4 +2,5 @@ install:
 
 
 test:
+	pod lib lint --quick
 	set -o pipefail && xcodebuild clean test -scheme RequestKit -sdk iphonesimulator | xcpretty -c

--- a/NBNRequestKit.podspec
+++ b/NBNRequestKit.podspec
@@ -1,5 +1,5 @@
 Pod::Spec.new do |s|
-  s.name             = "RequestKit"
+  s.name             = "NBNRequestKit"
   s.version          = "0.1.0"
   s.summary          = "Networking library for OctoKit.swift"
   s.homepage         = "https://github.com/nerdishbynature/RequestKit"

--- a/RequestKit.podspec
+++ b/RequestKit.podspec
@@ -1,0 +1,14 @@
+Pod::Spec.new do |s|
+  s.name             = "RequestKit"
+  s.version          = "0.1.0"
+  s.summary          = "Networking library for OctoKit.swift"
+  s.homepage         = "https://github.com/nerdishbynature/RequestKit"
+  s.license          = 'MIT'
+  s.author           = { "Piet Brauer" => "piet@nerdishbynature.com" }
+  s.source           = { :git => "https://github.com/nerdishbynature/RequestKit.git", :tag => s.version.to_s }
+  s.social_media_url = 'https://twitter.com/pietbrauer'
+  s.module_name     = "RequestKit"
+  s.platform     = :ios, '8.0'
+  s.requires_arc = true
+  s.source_files = 'RequestKit/*.swift'
+end


### PR DESCRIPTION
I'm hoping to give OctoKit.swift users the option of using CocoaPods as well as Carthage. This is the first step. 

Unfortunately, there's already a RequestKit on CocoaPods. (https://cocoapods.org/pods/RequestKit) In the mean time, we could pull in (this) RequestKit through git in the OctoKit.swift podspec.
