### PR TITLE
Remote unallowed characters from query and encode

### DIFF
--- a/RequestKit/Router.swift
+++ b/RequestKit/Router.swift
@@ -47,7 +47,8 @@ public extension Router {
         var components: [(String, String)] = []
         for key in parameters.keys.sort(<) {
             if let value = parameters[key] {
-                components.append(key, value)
+                let encodedValue = value.urlEncodedString()
+                components.append(key, encodedValue!)
             }
         }
 
@@ -59,7 +60,7 @@ public extension Router {
         switch encoding {
         case .URL, .JSON:
             if parameters.keys.count > 0 {
-                URLString = [URLString, urlQuery(parameters).urlEncodedString() ?? ""].joinWithSeparator("?")
+                URLString = [URLString, urlQuery(parameters) ?? ""].joinWithSeparator("?")
             }
             if let URL = NSURL(string: URLString) {
                 let mutableURLRequest = NSMutableURLRequest(URL: URL)

--- a/RequestKit/String+Additions.swift
+++ b/RequestKit/String+Additions.swift
@@ -5,6 +5,10 @@ public extension String {
     }
 
     func urlEncodedString() -> String? {
-        return self.stringByAddingPercentEncodingWithAllowedCharacters(.URLHostAllowedCharacterSet())
+        let generalDelimitersToEncode = ":#[]@" // does not include "?" or "/" due to RFC 3986 - Section 3.4
+        let subDelimitersToEncode = "!$&'()*+,;="
+        let characterSet = NSCharacterSet.URLQueryAllowedCharacterSet().mutableCopy() as! NSMutableCharacterSet
+        characterSet.removeCharactersInString(generalDelimitersToEncode + subDelimitersToEncode)
+        return stringByAddingPercentEncodingWithAllowedCharacters(characterSet)
     }
 }

--- a/RequestKitTests/StringAdditionsTests.swift
+++ b/RequestKitTests/StringAdditionsTests.swift
@@ -11,5 +11,8 @@ class StringAdditionsTests: XCTestCase {
     func testURLEncodedString() {
         let subject = "something with a space:<3"
         XCTAssertEqual(subject.urlEncodedString(), "something%20with%20a%20space%3A%3C3")
+
+        let subject2 = "2015-11-06T03:45:07.833168+00:00"
+        XCTAssertEqual(subject2.urlEncodedString(), "2015-11-06T03%3A45%3A07.833168%2B00%3A00")
     }
 }


### PR DESCRIPTION
Fixes bug with Bitbucket API where a timestamp in the query would contain a `+`
