### PR TITLE
Optional access token field name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ install:
 
 test:
 	pod lib lint --quick
-	set -o pipefail && xcodebuild clean test -scheme RequestKit -sdk iphonesimulator -enableCodeCoverage YES ONLY_ACTIVE_ARCHS=YES | xcpretty -c
+	set -o pipefail && xcodebuild clean test -scheme RequestKit -sdk iphonesimulator -enableCodeCoverage YES -destination name="iPhone 6" ONLY_ACTIVE_ARCHS=YES | xcpretty -c
 
 post_coverage:
 	bundle exec slather coverage --input-format profdata -x --ignore "../**/*/Xcode*" --ignore "Carthage/**" --output-directory slather-report --scheme RequestKit RequestKit.xcodeproj

--- a/RequestKit.xcodeproj/project.pbxproj
+++ b/RequestKit.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2301BEE21C1BEA3E001F3E54 /* ConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2301BEE11C1BEA3E001F3E54 /* ConfigurationTests.swift */; };
 		234F4C201BDDF64300A58EF7 /* RequestKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 234F4C1F1BDDF64300A58EF7 /* RequestKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		234F4C271BDDF64300A58EF7 /* RequestKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 234F4C1C1BDDF64300A58EF7 /* RequestKit.framework */; };
 		234F4C371BDDF6BF00A58EF7 /* Router.swift in Sources */ = {isa = PBXBuildFile; fileRef = 234F4C361BDDF6BF00A58EF7 /* Router.swift */; };
@@ -26,6 +27,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		2301BEE11C1BEA3E001F3E54 /* ConfigurationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConfigurationTests.swift; sourceTree = "<group>"; };
 		234F4C1C1BDDF64300A58EF7 /* RequestKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RequestKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		234F4C1F1BDDF64300A58EF7 /* RequestKit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RequestKit.h; sourceTree = "<group>"; };
 		234F4C211BDDF64300A58EF7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -91,6 +93,7 @@
 			children = (
 				234F4C2D1BDDF64300A58EF7 /* Info.plist */,
 				234F4C3A1BDE0B9200A58EF7 /* StringAdditionsTests.swift */,
+				2301BEE11C1BEA3E001F3E54 /* ConfigurationTests.swift */,
 			);
 			path = RequestKitTests;
 			sourceTree = "<group>";
@@ -213,6 +216,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2301BEE21C1BEA3E001F3E54 /* ConfigurationTests.swift in Sources */,
 				234F4C3B1BDE0B9200A58EF7 /* StringAdditionsTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/RequestKit/Router.swift
+++ b/RequestKit/Router.swift
@@ -18,6 +18,13 @@ public enum HTTPEncoding: Int {
 public protocol Configuration {
     var apiEndpoint: String { get }
     var accessToken: String? { get }
+    var accessTokenFieldName: String { get }
+}
+
+public extension Configuration {
+    var accessTokenFieldName: String {
+        return "access_token"
+    }
 }
 
 public protocol Router {
@@ -38,7 +45,7 @@ public extension Router {
         let URLString = configuration.apiEndpoint.stringByAppendingURLPath(path)
         var parameters = encoding == .JSON ? [:] : params
         if let accessToken = configuration.accessToken {
-            parameters["access_token"] = accessToken
+            parameters[configuration.accessTokenFieldName] = accessToken
         }
         return request(URLString, parameters: parameters)
     }

--- a/RequestKit/Router.swift
+++ b/RequestKit/Router.swift
@@ -92,7 +92,7 @@ public extension Router {
         if let request = request() {
             let task = NSURLSession.sharedSession().dataTaskWithRequest(request) { data, response, err in
                 if let response = response as? NSHTTPURLResponse {
-                    if response.statusCode != 200 {
+                    if response.statusCode <= 199 && response.statusCode > 299 {
                         let error = NSError(domain: errorDomain, code: response.statusCode, userInfo: nil)
                         completion(json: nil, error: error)
                         return

--- a/RequestKitTests/ConfigurationTests.swift
+++ b/RequestKitTests/ConfigurationTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+import RequestKit
+
+class ConfigurationTests: XCTestCase {
+    func testDefaultImplementation() {
+        let config = TestConfiguration("1234", url: "https://github.com")
+        XCTAssertEqual(config.apiEndpoint, "https://github.com")
+        XCTAssertEqual(config.accessToken, "1234")
+        XCTAssertEqual(config.accessTokenFieldName, "access_token")
+    }
+
+    func testCustomImplementation() {
+        let config = TestCustomConfiguration("1234", url: "https://github.com")
+        XCTAssertEqual(config.apiEndpoint, "https://github.com")
+        XCTAssertEqual(config.accessToken, "1234")
+        XCTAssertEqual(config.accessTokenFieldName, "custom_field")
+    }
+}
+
+class TestConfiguration: Configuration {
+    var apiEndpoint: String
+    var accessToken: String?
+
+    init(_ token: String, url: String) {
+        apiEndpoint = url
+        accessToken = token
+    }
+}
+
+class TestCustomConfiguration: Configuration {
+    var apiEndpoint: String
+    var accessToken: String?
+
+    init(_ token: String, url: String) {
+        apiEndpoint = url
+        accessToken = token
+    }
+
+    var accessTokenFieldName: String {
+        return "custom_field"
+    }
+}


### PR DESCRIPTION
- Add optional `accessTokenFieldName` to `Configuration` field which is needed because a private token configuration on GitLab Enterprise needs the field to be names `private_token` instead of `access_token`.
- Accept any status between 200 and 300 to be a success 
