### PR TITLE
Return task from loadJSON, postJSON

### DIFF
--- a/RequestKit/JSONPostRouter.swift
+++ b/RequestKit/JSONPostRouter.swift
@@ -1,40 +1,46 @@
 import Foundation
 
 public protocol JSONPostRouter: Router {
-    func postJSON<T>(session: RequestKitURLSession, expectedResultType: T.Type, completion: (json: T?, error: ErrorType?) -> Void)
+    func postJSON<T>(session: RequestKitURLSession, expectedResultType: T.Type, completion: (json: T?, error: ErrorType?) -> Void) -> URLSessionDataTaskProtocol?
 }
 
 public extension JSONPostRouter {
-    public func postJSON<T>(session: RequestKitURLSession = NSURLSession.sharedSession(), expectedResultType: T.Type, completion: (json: T?, error: ErrorType?) -> Void) {
-        do {
-            let data = try NSJSONSerialization.dataWithJSONObject(params, options: NSJSONWritingOptions())
-            if let request = request() {
-                let task = session.uploadTaskWithRequest(request, fromData: data) { data, response, error in
-                    if let response = response as? NSHTTPURLResponse {
-                        if response.statusCode != 201 {
-                            let error = NSError(domain: errorDomain, code: response.statusCode, userInfo: nil)
-                            completion(json: nil, error: error)
-                            return
-                        }
-                    }
+    public func postJSON<T>(session: RequestKitURLSession = NSURLSession.sharedSession(), expectedResultType: T.Type, completion: (json: T?, error: ErrorType?) -> Void) -> URLSessionDataTaskProtocol? {
+        guard let request = request() else {
+            return nil
+        }
 
-                    if let error = error {
-                        completion(json: nil, error: error)
-                    } else {
-                        if let data = data {
-                            do {
-                                let JSON = try NSJSONSerialization.JSONObjectWithData(data, options: .MutableContainers) as? T
-                                completion(json: JSON, error: nil)
-                            } catch {
-                                completion(json: nil, error: error)
-                            }
-                        }
-                    }
-                }
-                task.resume()
-            }
+        let data: NSData
+        do {
+            data = try NSJSONSerialization.dataWithJSONObject(params, options: NSJSONWritingOptions())
         } catch {
             completion(json: nil, error: error)
+            return nil
         }
+
+        let task = session.uploadTaskWithRequest(request, fromData: data) { data, response, error in
+            if let response = response as? NSHTTPURLResponse {
+                if response.statusCode != 201 {
+                    let error = NSError(domain: errorDomain, code: response.statusCode, userInfo: nil)
+                    completion(json: nil, error: error)
+                    return
+                }
+            }
+
+            if let error = error {
+                completion(json: nil, error: error)
+            } else {
+                if let data = data {
+                    do {
+                        let JSON = try NSJSONSerialization.JSONObjectWithData(data, options: .MutableContainers) as? T
+                        completion(json: JSON, error: nil)
+                    } catch {
+                        completion(json: nil, error: error)
+                    }
+                }
+            }
+        }
+        task.resume()
+        return task
     }
 }


### PR DESCRIPTION
This gives client code the opportunity to cancel the request if necessary.

Along the way, I also introduced a couple `guard` statements to make the code flow a little easier to follow.
