### PR TITLE
Allow passing accessToken with the Authorization header

### DIFF
--- a/RequestKit/Router.swift
+++ b/RequestKit/Router.swift
@@ -17,7 +17,7 @@ public protocol Configuration {
     var apiEndpoint: String { get }
     var accessToken: String? { get }
     var accessTokenFieldName: String { get }
-    var shouldUseAuthorizationHeader: Bool { get }
+    var authorizationHeader: String? { get }
     var errorDomain: String { get }
 }
 
@@ -26,8 +26,8 @@ public extension Configuration {
         return "access_token"
     }
 
-    var shouldUseAuthorizationHeader: Bool {
-        return false
+    var authorizationHeader: String? {
+        return nil
     }
     
     var errorDomain: String {
@@ -57,15 +57,15 @@ public extension Router {
         let url = URL(string: path, relativeTo: URL(string: configuration.apiEndpoint)!)
         var parameters = encoding == .json ? [:] : params
 
-        if let accessToken = configuration.accessToken, !configuration.shouldUseAuthorizationHeader {
+        if let accessToken = configuration.accessToken, configuration.authorizationHeader == nil {
             parameters[configuration.accessTokenFieldName] = accessToken as AnyObject?
         }
         let components = URLComponents(url: url!, resolvingAgainstBaseURL: true)
         
         var urlRequest = request(components!, parameters: parameters)
         
-        if configuration.shouldUseAuthorizationHeader, let accessToken = configuration.accessToken {
-            urlRequest?.addValue("BEARER \(accessToken)", forHTTPHeaderField: "Authorization")
+        if let accessToken = configuration.accessToken, let tokenType = configuration.authorizationHeader {
+            urlRequest?.addValue("\(tokenType) \(accessToken)", forHTTPHeaderField: "Authorization")
         }
         
         return urlRequest

--- a/RequestKit/Router.swift
+++ b/RequestKit/Router.swift
@@ -17,6 +17,7 @@ public protocol Configuration {
     var apiEndpoint: String { get }
     var accessToken: String? { get }
     var accessTokenFieldName: String { get }
+    var shouldUseAuthorizationHeader: Bool { get }
     var errorDomain: String { get }
 }
 
@@ -25,6 +26,10 @@ public extension Configuration {
         return "access_token"
     }
 
+    var shouldUseAuthorizationHeader: Bool {
+        return false
+    }
+    
     var errorDomain: String {
         return "com.nerdishbynature.RequestKit"
     }
@@ -51,11 +56,19 @@ public extension Router {
     public func request() -> URLRequest? {
         let url = URL(string: path, relativeTo: URL(string: configuration.apiEndpoint)!)
         var parameters = encoding == .json ? [:] : params
-        if let accessToken = configuration.accessToken {
+
+        if let accessToken = configuration.accessToken, !configuration.shouldUseAuthorizationHeader {
             parameters[configuration.accessTokenFieldName] = accessToken as AnyObject?
         }
         let components = URLComponents(url: url!, resolvingAgainstBaseURL: true)
-        return request(components!, parameters: parameters)
+        
+        var urlRequest = request(components!, parameters: parameters)
+        
+        if configuration.shouldUseAuthorizationHeader, let accessToken = configuration.accessToken {
+            urlRequest?.addValue("BEARER \(accessToken)", forHTTPHeaderField: "Authorization")
+        }
+        
+        return urlRequest
     }
 
     public func urlQuery(_ parameters: [String: Any]) -> [URLQueryItem]? {

--- a/RequestKitTests/ConfigurationTests.swift
+++ b/RequestKitTests/ConfigurationTests.swift
@@ -7,6 +7,7 @@ class ConfigurationTests: XCTestCase {
         XCTAssertEqual(config.apiEndpoint, "https://github.com")
         XCTAssertEqual(config.accessToken, "1234")
         XCTAssertEqual(config.accessTokenFieldName, "access_token")
+        XCTAssertEqual(config.authorizationHeader, nil)
     }
 
     func testCustomImplementation() {
@@ -14,6 +15,15 @@ class ConfigurationTests: XCTestCase {
         XCTAssertEqual(config.apiEndpoint, "https://github.com")
         XCTAssertEqual(config.accessToken, "1234")
         XCTAssertEqual(config.accessTokenFieldName, "custom_field")
+        XCTAssertEqual(config.authorizationHeader, nil)
+    }
+    
+    func testAuthorizationHeaderConfiguration() {
+        let config = TestAuthorizationHeaderConfiguration("1234", url: "https://github.com")
+        XCTAssertEqual(config.apiEndpoint, "https://github.com")
+        XCTAssertEqual(config.accessToken, "1234")
+        XCTAssertEqual(config.accessTokenFieldName, "access_token")
+        XCTAssertEqual(config.authorizationHeader, "BEARER")
     }
 }
 
@@ -38,5 +48,19 @@ class TestCustomConfiguration: Configuration {
 
     var accessTokenFieldName: String {
         return "custom_field"
+    }
+}
+
+class TestAuthorizationHeaderConfiguration: Configuration {
+    var apiEndpoint: String
+    var accessToken: String?
+    
+    init(_ token: String, url: String) {
+        apiEndpoint = url
+        accessToken = token
+    }
+
+    var authorizationHeader: String? {
+        return "BEARER"
     }
 }

--- a/RequestKitTests/RouterTests.swift
+++ b/RequestKitTests/RouterTests.swift
@@ -12,6 +12,15 @@ class RouterTests: XCTestCase {
         let subject = router.request()
         XCTAssertEqual(subject?.url?.absoluteString, "https://example.com/api/v1/some_route?access_token=1234&key1=value1%3A456&key2=value2")
         XCTAssertEqual(subject?.httpMethod, "GET")
+    }    
+    
+    func testRequestWithAuthorizationHeader() {
+        let config = TestAuthorizationHeaderConfiguration("1234", url: "https://example.com/api/v1/")
+        let router = TestRouter.testRoute(config)
+        let subject = router.request()
+        XCTAssertEqual(subject?.url?.absoluteString, "https://example.com/api/v1/some_route?key1=value1%3A456&key2=value2")
+        XCTAssertEqual(subject?.httpMethod, "GET")
+        XCTAssertEqual(subject?.value(forHTTPHeaderField: "Authorization"), "BEARER 1234")
     }
 
     func testWasSuccessful() {


### PR DESCRIPTION
This would allow the accessToken to be (optionally) passed as a Bearer token in the Authorization header instead of as a URL parameter.

I still need to add tests but before that I wanted to make sure this is something you would consider and ask if there is anything else I should do / consider for this?
