### PR TITLE
Support for API endpoints that have empty results

### DIFF
--- a/RequestKit/Router.swift
+++ b/RequestKit/Router.swift
@@ -164,6 +164,30 @@ public extension Router {
         task.resume()
         return task
     }
+    
+    public func load(_ session: RequestKitURLSession = URLSession.shared, completion: @escaping (_ error: Error?) -> Void) -> URLSessionDataTaskProtocol? {
+        guard let request = request() else {
+            return nil
+        }
+        
+        let task = session.dataTask(with: request) { data, response, err in
+            if let response = response as? HTTPURLResponse {
+                if response.wasSuccessful == false {
+                    var userInfo = [String: AnyObject]()
+                    if let data = data, let json = try? JSONSerialization.jsonObject(with: data, options: .mutableContainers) as? [String: AnyObject] {
+                        userInfo[RequestKitErrorKey] = json as AnyObject?
+                    }
+                    let error = NSError(domain: self.configuration.errorDomain, code: response.statusCode, userInfo: userInfo)
+                    completion(error)
+                    return
+                }
+            }
+            
+            completion(err)
+        }
+        task.resume()
+        return task
+    }
 }
 
 fileprivate extension CharacterSet {

--- a/RequestKitTests/TestInterface.swift
+++ b/RequestKitTests/TestInterface.swift
@@ -40,6 +40,17 @@ class TestInterface {
             }
         }
     }
+    
+    func loadAndIgnoreResponseBody(_ session: RequestKitURLSession = URLSession.shared, completion: @escaping (_ response: Response<Void>) -> Void) -> URLSessionDataTaskProtocol? {
+        let router = JSONTestRouter.testPOST(configuration)
+        return router.load(session) { error in
+            if let error = error {
+                completion(Response.failure(error))
+            } else {
+                completion(Response.success(()))
+            }
+        }
+    }
 }
 
 enum JSONTestRouter: JSONPostRouter {


### PR DESCRIPTION
This adds a new `load` function to `Router` for when we don't expect the web service to return an object. This would be used for example when we expect an API endpoint to return a `204 No Content` or a `200 OK` with an empty body.

This `load` function does exactly the same thing as the current `load` function except it ignores the response body / doesn't attempt to parse it. 

I don't _think_ there is another way to support this using the current API since the current `load` function requires a `expectedResultType` parameter that conforms to `Codable`

WDYT?