### PR TITLE
Add support for configuring JSONDecoder.keyDecodingStrategy in Xcode 9.3

### DIFF
--- a/RequestKit/JSONPostRouter.swift
+++ b/RequestKit/JSONPostRouter.swift
@@ -51,7 +51,7 @@ public extension JSONPostRouter {
         return task
     }
 
-    public func post<T: Codable>(_ session: RequestKitURLSession = URLSession.shared, expectedResultType: T.Type, completion: @escaping (_ json: T?, _ error: Error?) -> Void) -> URLSessionDataTaskProtocol? {
+    public func post<T: Codable>(_ session: RequestKitURLSession = URLSession.shared, decoder:JSONDecoder = JSONDecoder(), expectedResultType: T.Type, completion: @escaping (_ json: T?, _ error: Error?) -> Void) -> URLSessionDataTaskProtocol? {
         guard let request = request() else {
             return nil
         }
@@ -84,7 +84,7 @@ public extension JSONPostRouter {
             } else {
                 if let data = data {
                     do {
-                        let decoded = try JSONDecoder().decode(T.self, from: data)
+                        let decoded = try decoder.decode(T.self, from: data)
                         completion(decoded, nil)
                     } catch {
                         completion(nil, error)

--- a/RequestKit/JSONPostRouter.swift
+++ b/RequestKit/JSONPostRouter.swift
@@ -2,7 +2,7 @@ import Foundation
 
 public protocol JSONPostRouter: Router {
     func postJSON<T>(_ session: RequestKitURLSession, expectedResultType: T.Type, completion: @escaping (_ json: T?, _ error: Error?) -> Void) -> URLSessionDataTaskProtocol?
-    func post<T: Codable>(_ session: RequestKitURLSession, expectedResultType: T.Type, completion: @escaping (_ json: T?, _ error: Error?) -> Void) -> URLSessionDataTaskProtocol?
+    func post<T: Codable>(_ session: RequestKitURLSession, decoder:JSONDecoder, expectedResultType: T.Type, completion: @escaping (_ json: T?, _ error: Error?) -> Void) -> URLSessionDataTaskProtocol?
 }
 
 public extension JSONPostRouter {

--- a/RequestKit/Router.swift
+++ b/RequestKit/Router.swift
@@ -47,7 +47,7 @@ public protocol Router {
     func urlQuery(_ parameters: [String: Any]) -> [URLQueryItem]?
     func request(_ urlComponents: URLComponents, parameters: [String: Any]) -> URLRequest?
     func loadJSON<T: Codable>(_ session: RequestKitURLSession, expectedResultType: T.Type, completion: @escaping (_ json: T?, _ error: Error?) -> Void) -> URLSessionDataTaskProtocol?
-    func load<T: Codable>(_ session: RequestKitURLSession, dateDecodingStrategy: JSONDecoder.DateDecodingStrategy, expectedResultType: T.Type, completion: @escaping (_ json: T?, _ error: Error?) -> Void) -> URLSessionDataTaskProtocol?
+    func load<T: Codable>(_ session: RequestKitURLSession, dateDecodingStrategy: JSONDecoder.DateDecodingStrategy?, expectedResultType: T.Type, completion: @escaping (_ json: T?, _ error: Error?) -> Void) -> URLSessionDataTaskProtocol?
     func load<T: Codable>(_ session: RequestKitURLSession, decoder: JSONDecoder, expectedResultType: T.Type, completion: @escaping (_ json: T?, _ error: Error?) -> Void) -> URLSessionDataTaskProtocol?
     func request() -> URLRequest?
 }
@@ -126,9 +126,11 @@ public extension Router {
         return load(session, expectedResultType: expectedResultType, completion: completion)
     }
 
-    public func load<T: Codable>(_ session: RequestKitURLSession = URLSession.shared, dateDecodingStrategy: JSONDecoder.DateDecodingStrategy, expectedResultType: T.Type, completion: @escaping (_ json: T?, _ error: Error?) -> Void) -> URLSessionDataTaskProtocol? {        
+    public func load<T: Codable>(_ session: RequestKitURLSession = URLSession.shared, dateDecodingStrategy: JSONDecoder.DateDecodingStrategy?, expectedResultType: T.Type, completion: @escaping (_ json: T?, _ error: Error?) -> Void) -> URLSessionDataTaskProtocol? {
         let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = dateDecodingStrategy
+        if let dateDecodingStrategy = dateDecodingStrategy {
+            decoder.dateDecodingStrategy = dateDecodingStrategy
+        }
         return load(session, decoder:decoder, expectedResultType:expectedResultType, completion:completion)
     }
 

--- a/RequestKit/Router.swift
+++ b/RequestKit/Router.swift
@@ -123,10 +123,20 @@ public extension Router {
 
     @available(*, deprecated, message: "Plase use `load` method instead")
     public func loadJSON<T: Codable>(_ session: RequestKitURLSession = URLSession.shared, expectedResultType: T.Type, completion: @escaping (_ json: T?, _ error: Error?) -> Void) -> URLSessionDataTaskProtocol? {
-        return load(session, expectedResultType: expectedResultType, completion: completion)
+        return load(session, dateDecodingStrategy:nil, expectedResultType: expectedResultType, completion: completion)
     }
 
     public func load<T: Codable>(_ session: RequestKitURLSession = URLSession.shared, dateDecodingStrategy: JSONDecoder.DateDecodingStrategy? = nil, expectedResultType: T.Type, completion: @escaping (_ json: T?, _ error: Error?) -> Void) -> URLSessionDataTaskProtocol? {
+        
+        let decoder = JSONDecoder()
+        if let dateDecodingStrategy = dateDecodingStrategy {
+            decoder.dateDecodingStrategy = dateDecodingStrategy
+        }
+        
+        return load(session, decoder:decoder, expectedResultType:expectedResultType, completion:completion)
+    }
+
+    public func load<T: Codable>(_ session: RequestKitURLSession = URLSession.shared, decoder: JSONDecoder = JSONDecoder(), expectedResultType: T.Type, completion: @escaping (_ json: T?, _ error: Error?) -> Void) -> URLSessionDataTaskProtocol? {
         guard let request = request() else {
             return nil
         }
@@ -149,10 +159,6 @@ public extension Router {
             } else {
                 if let data = data {
                     do {
-                        let decoder = JSONDecoder()
-                        if let dateDecodingStrategy = dateDecodingStrategy {
-                            decoder.dateDecodingStrategy = dateDecodingStrategy
-                        }
                         let decoded = try decoder.decode(T.self, from: data)
                         completion(decoded, nil)
                     } catch {

--- a/RequestKit/Router.swift
+++ b/RequestKit/Router.swift
@@ -47,8 +47,8 @@ public protocol Router {
     func urlQuery(_ parameters: [String: Any]) -> [URLQueryItem]?
     func request(_ urlComponents: URLComponents, parameters: [String: Any]) -> URLRequest?
     func loadJSON<T: Codable>(_ session: RequestKitURLSession, expectedResultType: T.Type, completion: @escaping (_ json: T?, _ error: Error?) -> Void) -> URLSessionDataTaskProtocol?
-    func load<T: Codable>(_ session: RequestKitURLSession, dateDecodingStrategy: JSONDecoder.DateDecodingStrategy?, expectedResultType: T.Type, completion: @escaping (_ json: T?, _ error: Error?) -> Void) -> URLSessionDataTaskProtocol?
-
+    func load<T: Codable>(_ session: RequestKitURLSession, dateDecodingStrategy: JSONDecoder.DateDecodingStrategy, expectedResultType: T.Type, completion: @escaping (_ json: T?, _ error: Error?) -> Void) -> URLSessionDataTaskProtocol?
+    func load<T: Codable>(_ session: RequestKitURLSession, decoder: JSONDecoder, expectedResultType: T.Type, completion: @escaping (_ json: T?, _ error: Error?) -> Void) -> URLSessionDataTaskProtocol?
     func request() -> URLRequest?
 }
 
@@ -123,16 +123,12 @@ public extension Router {
 
     @available(*, deprecated, message: "Plase use `load` method instead")
     public func loadJSON<T: Codable>(_ session: RequestKitURLSession = URLSession.shared, expectedResultType: T.Type, completion: @escaping (_ json: T?, _ error: Error?) -> Void) -> URLSessionDataTaskProtocol? {
-        return load(session, dateDecodingStrategy:nil, expectedResultType: expectedResultType, completion: completion)
+        return load(session, expectedResultType: expectedResultType, completion: completion)
     }
 
-    public func load<T: Codable>(_ session: RequestKitURLSession = URLSession.shared, dateDecodingStrategy: JSONDecoder.DateDecodingStrategy? = nil, expectedResultType: T.Type, completion: @escaping (_ json: T?, _ error: Error?) -> Void) -> URLSessionDataTaskProtocol? {
-        
+    public func load<T: Codable>(_ session: RequestKitURLSession = URLSession.shared, dateDecodingStrategy: JSONDecoder.DateDecodingStrategy, expectedResultType: T.Type, completion: @escaping (_ json: T?, _ error: Error?) -> Void) -> URLSessionDataTaskProtocol? {        
         let decoder = JSONDecoder()
-        if let dateDecodingStrategy = dateDecodingStrategy {
-            decoder.dateDecodingStrategy = dateDecodingStrategy
-        }
-        
+        decoder.dateDecodingStrategy = dateDecodingStrategy
         return load(session, decoder:decoder, expectedResultType:expectedResultType, completion:completion)
     }
 


### PR DESCRIPTION
Starting with Xcode 9.3 (currently in beta) there is a nice new property in `JSONDecoder` called `keyDecodingStrategy` that I would like to customize (once it is out of beta). https://benscheirman.com/2018/02/swift-4-1-keydecodingstrategy

This pull request is intended to explore and discuss the options and tradeoffs of ways to support this.

**Option 1** - Add a new optional `keyDecodingStrategy` argument to `load`. The main problem with this is that it will break when building with versions prior to Xcode 9.3. (How long should we support Xcode 9.2?). It also feels a _little_ dirty to accept multiple arguments to configure a single `JSONDecoder` but maybe that is OK.

**Option 2** - Add a new optional `JSONDecoder` parameter to the existing `load` function. This would be a little weird because it would allow passing both a `dateDecodingStrategy` and a `JSONDecoder` and it wouldn't be super obvious what we would do if the user provided both.

**Option 3** - The attached code just creates a second `load` method that accepts an optional `JSONDecoder` argument instead of `dateDecodingStrategy`. This isn't practical though because the compiler will complain if you try to call `load` without the second argument (it would be an ambiguous function call)

**Option 4** - Ideally we would do Option 3 but also delete the old `load` method. The problem with this is that it breaks backwards source compatibility and I wasn't sure how strict this project is with that. Existing API users who previously provided a `dateDecodingStrategy` argument would need to update their code to instead pass a `JSONDecoder`.

**Option 5** - The simple solution is Option 3 but rename the new `load` method to something else . Coming up with a new name is the hard part. :-)

Any other thoughts / ideas? WDYT?
