### PR TITLE
Prepare for version to 2.2.0

### DIFF
--- a/NBNRequestKit.podspec
+++ b/NBNRequestKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "NBNRequestKit"
-  s.version          = "2.1.0"
+  s.version          = "2.2.0"
   s.summary          = "Networking library for OctoKit.swift"
   s.homepage         = "https://github.com/nerdishbynature/RequestKit"
   s.license          = 'MIT'

--- a/RequestKit/Info.plist
+++ b/RequestKit/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1.0</string>
+	<string>2.2.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
Once pull request https://github.com/nerdishbynature/RequestKit/pull/46 is closed I'd love to publish a version 2.2.0. Changes in Version 2.2.0: 
- Allow passing accessToken with the Authorization header
- Support for API endpoints that have empty results 
- Allow clients to pass their own JSONDecoder
- Updated documentation

Are there any other changes required to perform a 2.2.0 release? (Other than adding the CocoPods spec to the specs repo)
