### PR TITLE
Update Package.swift to support 4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
     - os: linux
       sudo: required
       dist: trusty
-      env: SWIFT_VERSION=4.1
+      env: SWIFT_VERSION=4.2
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./script/travis-install-linux; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ./script/travis-install-macos; fi

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.0
+// swift-tools-version:4.2
 import PackageDescription
 
 let package = Package(
@@ -9,5 +9,6 @@ let package = Package(
     targets: [
         .target(name: "RequestKit", dependencies: []),
         .testTarget(name: "RequestKitTests", dependencies: ["RequestKit"])
-   ]
+   ],
+   swiftLanguageVersions: [.version("3.0"), .version("4.0"), .version("4.1"), .version("4.2")]
 )


### PR DESCRIPTION
I am building a personal project [here](https://github.com/shkhaliq/automatic-branch-merging). I want to use octokit but realized it doesn't have support for SwiftPM. 
I am updating the RequestKit PM to  Swift 4.2 and have a subsequent PR for octokit thats ready to [go](https://github.com/nerdishbynature/octokit.swift/compare/master...shkhaliq:add-package-manager?expand=1) to add support for Swift PM

Some of the xcodeproj files got updated after I ran generate-xcodeproj but I decided not to include those.