### PR TITLE
Synchronous dispatch

### DIFF
--- a/RequestKit.xcodeproj/project.pbxproj
+++ b/RequestKit.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		7679C02320AB08290052BBDC /* TestInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7679C00C20AB08290052BBDC /* TestInterface.swift */; };
 		7679C02420AB08290052BBDC /* TestInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7679C00C20AB08290052BBDC /* TestInterface.swift */; };
 		7679C02520AB08290052BBDC /* TestInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7679C00C20AB08290052BBDC /* TestInterface.swift */; };
+		9D12C43721A9E4AB00D2AD50 /* JSONPostRouterSynchronousDispatchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D12C43621A9E4AB00D2AD50 /* JSONPostRouterSynchronousDispatchTests.swift */; };
 		9D1CFBDA21A96378001EEA08 /* RouterSynchronousDispatchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D1CFBD921A96378001EEA08 /* RouterSynchronousDispatchTests.swift */; };
 /* End PBXBuildFile section */
 
@@ -96,6 +97,7 @@
 		7679C00B20AB08290052BBDC /* JSONPostRouterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONPostRouterTests.swift; sourceTree = "<group>"; };
 		7679C00C20AB08290052BBDC /* TestInterface.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestInterface.swift; sourceTree = "<group>"; };
 		7679C00D20AB08290052BBDC /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		9D12C43621A9E4AB00D2AD50 /* JSONPostRouterSynchronousDispatchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONPostRouterSynchronousDispatchTests.swift; sourceTree = "<group>"; };
 		9D1CFBD921A96378001EEA08 /* RouterSynchronousDispatchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouterSynchronousDispatchTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -219,6 +221,7 @@
 				7679C00820AB08290052BBDC /* XCTestManifests.swift */,
 				7679C00D20AB08290052BBDC /* Info.plist */,
 				9D1CFBD921A96378001EEA08 /* RouterSynchronousDispatchTests.swift */,
+				9D12C43621A9E4AB00D2AD50 /* JSONPostRouterSynchronousDispatchTests.swift */,
 			);
 			path = RequestKitTests;
 			sourceTree = "<group>";
@@ -528,6 +531,7 @@
 				7679C02320AB08290052BBDC /* TestInterface.swift in Sources */,
 				7679C01D20AB08290052BBDC /* TestHelper.swift in Sources */,
 				7679C01720AB08290052BBDC /* XCTestManifests.swift in Sources */,
+				9D12C43721A9E4AB00D2AD50 /* JSONPostRouterSynchronousDispatchTests.swift in Sources */,
 				7679C02020AB08290052BBDC /* JSONPostRouterTests.swift in Sources */,
 				9D1CFBDA21A96378001EEA08 /* RouterSynchronousDispatchTests.swift in Sources */,
 				7679C01420AB08290052BBDC /* RouterTests.swift in Sources */,

--- a/RequestKit.xcodeproj/project.pbxproj
+++ b/RequestKit.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		7679C02320AB08290052BBDC /* TestInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7679C00C20AB08290052BBDC /* TestInterface.swift */; };
 		7679C02420AB08290052BBDC /* TestInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7679C00C20AB08290052BBDC /* TestInterface.swift */; };
 		7679C02520AB08290052BBDC /* TestInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7679C00C20AB08290052BBDC /* TestInterface.swift */; };
+		9D1CFBDA21A96378001EEA08 /* RouterSynchronousDispatchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D1CFBD921A96378001EEA08 /* RouterSynchronousDispatchTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -95,6 +96,7 @@
 		7679C00B20AB08290052BBDC /* JSONPostRouterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONPostRouterTests.swift; sourceTree = "<group>"; };
 		7679C00C20AB08290052BBDC /* TestInterface.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestInterface.swift; sourceTree = "<group>"; };
 		7679C00D20AB08290052BBDC /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		9D1CFBD921A96378001EEA08 /* RouterSynchronousDispatchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouterSynchronousDispatchTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -199,11 +201,6 @@
 		7679C00320AB08290052BBDC /* Tests */ = {
 			isa = PBXGroup;
 			children = (
-				234F4C2D1BDDF64300A58EF7 /* Info.plist */,
-				2301BEE11C1BEA3E001F3E54 /* ConfigurationTests.swift */,
-				2301BEE31C1BF95E001F3E54 /* RouterTests.swift */,
-				2352906C1D03B68A004FD7FB /* JSONPostRouterTests.swift */,
-				235290741D03B9FE004FD7FB /* TestInterface.swift */,
 				7679C00420AB08290052BBDC /* LinuxMain.swift */,
 				7679C00520AB08290052BBDC /* RequestKitTests */,
 			);
@@ -221,6 +218,7 @@
 				7679C00A20AB08290052BBDC /* TestHelper.swift */,
 				7679C00820AB08290052BBDC /* XCTestManifests.swift */,
 				7679C00D20AB08290052BBDC /* Info.plist */,
+				9D1CFBD921A96378001EEA08 /* RouterSynchronousDispatchTests.swift */,
 			);
 			path = RequestKitTests;
 			sourceTree = "<group>";
@@ -531,6 +529,7 @@
 				7679C01D20AB08290052BBDC /* TestHelper.swift in Sources */,
 				7679C01720AB08290052BBDC /* XCTestManifests.swift in Sources */,
 				7679C02020AB08290052BBDC /* JSONPostRouterTests.swift in Sources */,
+				9D1CFBDA21A96378001EEA08 /* RouterSynchronousDispatchTests.swift in Sources */,
 				7679C01420AB08290052BBDC /* RouterTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/RequestKit/JSONPostRouter.swift
+++ b/Sources/RequestKit/JSONPostRouter.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 public protocol JSONPostRouter: Router {
-    func postJSON<T>(_ session: RequestKitURLSession, expectedResultType: T.Type, completion: @escaping (_ json: T?, _ error: Error?) -> Void) -> URLSessionDataTaskProtocol?
-    func post<T: Codable>(_ session: RequestKitURLSession, decoder:JSONDecoder, expectedResultType: T.Type, completion: @escaping (_ json: T?, _ error: Error?) -> Void) -> URLSessionDataTaskProtocol?
+    func postJSON<T>(_ session: RequestKitURLSession, expectedResultType: T.Type, completion: @escaping JSONCompletionBlock<T>) -> URLSessionDataTaskProtocol?
+    func post<T: Codable>(_ session: RequestKitURLSession, decoder:JSONDecoder, expectedResultType: T.Type, completion: @escaping JSONCompletionBlock<T>) -> URLSessionDataTaskProtocol?
 }
 
 public extension JSONPostRouter {
-    public func postJSON<T>(_ session: RequestKitURLSession = URLSession.shared, expectedResultType: T.Type, completion: @escaping (_ json: T?, _ error: Error?) -> Void) -> URLSessionDataTaskProtocol? {
+    public func postJSON<T>(_ session: RequestKitURLSession = URLSession.shared, expectedResultType: T.Type, completion: @escaping JSONCompletionBlock<T>) -> URLSessionDataTaskProtocol? {
         guard let request = request() else {
             return nil
         }
@@ -55,7 +55,7 @@ public extension JSONPostRouter {
         return task
     }
 
-    public func post<T: Codable>(_ session: RequestKitURLSession = URLSession.shared, decoder:JSONDecoder = JSONDecoder(), expectedResultType: T.Type, completion: @escaping (_ json: T?, _ error: Error?) -> Void) -> URLSessionDataTaskProtocol? {
+    public func post<T: Codable>(_ session: RequestKitURLSession = URLSession.shared, decoder:JSONDecoder = JSONDecoder(), expectedResultType: T.Type, completion: @escaping JSONCompletionBlock<T>) -> URLSessionDataTaskProtocol? {
         guard let request = request() else {
             return nil
         }

--- a/Sources/RequestKit/JSONPostRouter.swift
+++ b/Sources/RequestKit/JSONPostRouter.swift
@@ -18,6 +18,9 @@ public extension JSONPostRouter {
             completion(nil, error)
             return nil
         }
+        
+        let dispatchGroup = dispatchGroupIfNeeded()
+        let dispatchGroupCompletion = jsonDispatchGroupCompletion(dispatchGroup: dispatchGroup, completion: completion)
 
         let task = session.uploadTask(with: request, fromData: data) { data, response, error in
             if let response = response as? HTTPURLResponse {
@@ -29,25 +32,26 @@ public extension JSONPostRouter {
                         userInfo[RequestKitErrorKey] = string as Any?
                     }
                     let error = NSError(domain: self.configuration.errorDomain, code: response.statusCode, userInfo: userInfo)
-                    completion(nil, error)
+                    dispatchGroupCompletion(nil, error)
                     return
                 }
             }
 
             if let error = error {
-                completion(nil, error)
+                dispatchGroupCompletion(nil, error)
             } else {
                 if let data = data {
                     do {
                         let JSON = try JSONSerialization.jsonObject(with: data, options: .mutableContainers) as? T
-                        completion(JSON, nil)
+                        dispatchGroupCompletion(JSON, nil)
                     } catch {
-                        completion(nil, error)
+                        dispatchGroupCompletion(nil, error)
                     }
                 }
             }
         }
         task.resume()
+        dispatchGroup?.wait()
         return task
     }
 
@@ -63,6 +67,9 @@ public extension JSONPostRouter {
             completion(nil, error)
             return nil
         }
+        
+        let dispatchGroup = dispatchGroupIfNeeded()
+        let dispatchGroupCompletion = jsonDispatchGroupCompletion(dispatchGroup: dispatchGroup, completion: completion)
 
         let task = session.uploadTask(with: request, fromData: data) { data, response, error in
             if let response = response as? HTTPURLResponse {
@@ -74,25 +81,26 @@ public extension JSONPostRouter {
                         userInfo[RequestKitErrorKey] = string as Any?
                     }
                     let error = NSError(domain: self.configuration.errorDomain, code: response.statusCode, userInfo: userInfo)
-                    completion(nil, error)
+                    dispatchGroupCompletion(nil, error)
                     return
                 }
             }
 
             if let error = error {
-                completion(nil, error)
+                dispatchGroupCompletion(nil, error)
             } else {
                 if let data = data {
                     do {
                         let decoded = try decoder.decode(T.self, from: data)
-                        completion(decoded, nil)
+                        dispatchGroupCompletion(decoded, nil)
                     } catch {
-                        completion(nil, error)
+                        dispatchGroupCompletion(nil, error)
                     }
                 }
             }
         }
         task.resume()
+        dispatchGroup?.wait()
         return task
     }
 }

--- a/Tests/RequestKitTests/JSONPostRouterSynchronousDispatchTests.swift
+++ b/Tests/RequestKitTests/JSONPostRouterSynchronousDispatchTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 
 final class JSONPostRouterSynchronousDispatchTests: XCTestCase {
+#if !os(Linux)
     static var allTests = [
         ("testPostJSONErrorWaitsForTheResponseIfDispatchSynchronousIsTrue", testPostJSONErrorWaitsForTheResponseIfDispatchSynchronousIsTrue),
         ("testPostJSONErrorDoesntWaitsForTheResponseIfDispatchSynchronousIsFalse", testPostJSONErrorDoesntWaitsForTheResponseIfDispatchSynchronousIsFalse),
@@ -104,4 +105,5 @@ final class JSONPostRouterSynchronousDispatchTests: XCTestCase {
     private func jsonString(withJsonDict jsonDict: [String : String]) -> String? {
         return String(data: try! JSONSerialization.data(withJSONObject: jsonDict, options: JSONSerialization.WritingOptions()), encoding: String.Encoding.utf8)
     }
+#endif
 }

--- a/Tests/RequestKitTests/JSONPostRouterSynchronousDispatchTests.swift
+++ b/Tests/RequestKitTests/JSONPostRouterSynchronousDispatchTests.swift
@@ -9,6 +9,24 @@
 import XCTest
 
 final class JSONPostRouterSynchronousDispatchTests: XCTestCase {
+    static var allTests = [
+        ("testPostJSONErrorWaitsForTheResponseIfDispatchSynchronousIsTrue", testPostJSONErrorWaitsForTheResponseIfDispatchSynchronousIsTrue),
+        ("testPostJSONErrorDoesntWaitsForTheResponseIfDispatchSynchronousIsFalse", testPostJSONErrorDoesntWaitsForTheResponseIfDispatchSynchronousIsFalse),
+        ("testPostJSONSuccessWaitsForTheResponseIfDispatchSynchronousIsTrue", testPostJSONSuccessWaitsForTheResponseIfDispatchSynchronousIsTrue),
+        ("testPostJSONSuccessDoesntWaitsForTheResponseIfDispatchSynchronousIsFalse", testPostJSONSuccessDoesntWaitsForTheResponseIfDispatchSynchronousIsFalse),
+        ("testLinuxTestSuiteIncludesAllTests", testLinuxTestSuiteIncludesAllTests)
+    ]
+    
+    func testLinuxTestSuiteIncludesAllTests() {
+        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+        let thisClass = type(of: self)
+        let linuxCount = thisClass.allTests.count
+        let darwinCount = thisClass.defaultTestSuite.tests.count
+        XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from allTests")
+        #endif
+    }
+
+    
     func testPostJSONErrorWaitsForTheResponseIfDispatchSynchronousIsTrue() {
         let response = jsonString(withJsonDict: failureDict)
         let session = DelayedRequestKitURLTestSession(response: response, statusCode: 401)

--- a/Tests/RequestKitTests/JSONPostRouterSynchronousDispatchTests.swift
+++ b/Tests/RequestKitTests/JSONPostRouterSynchronousDispatchTests.swift
@@ -1,0 +1,89 @@
+//
+//  JSONPostRouterSynchronousDispatchTests.swift
+//  RequestKitTests
+//
+//  Created by Franco on 24/11/2018.
+//  Copyright © 2018 nerdishbynature. All rights reserved.
+//
+
+import XCTest
+
+final class JSONPostRouterSynchronousDispatchTests: XCTestCase {
+    func testPostJSONErrorWaitsForTheResponseIfDispatchSynchronousIsTrue() {
+        let response = jsonString(withJsonDict: failureDict)
+        let session = DelayedRequestKitURLTestSession(response: response, statusCode: 401)
+        var wasCalled = false
+        _ = TestInterface().postJSON(session, synchronousDispatch: true) { response in
+            switch response {
+            case .success:
+                XCTFail("Should not retrieve a succesful response")
+            case .failure:
+                wasCalled = true
+            }
+        }
+        XCTAssertTrue(wasCalled)
+    }
+    
+    func testPostJSONErrorDoesntWaitsForTheResponseIfDispatchSynchronousIsFalse() {
+        let response = jsonString(withJsonDict: failureDict)
+        let session = DelayedRequestKitURLTestSession(response: response, statusCode: 401)
+        var wasCalled = false
+        let expectation = XCTestExpectation(description: "Session expectation")
+        
+        _ = TestInterface().postJSON(session, synchronousDispatch: false) { response in
+            switch response {
+            case .success:
+                XCTFail("Should not retrieve a succesful response")
+            case .failure:
+                wasCalled = true
+                expectation.fulfill()
+            }
+        }
+            
+        XCTAssertFalse(wasCalled)
+        wait(for: [expectation], timeout: 1)
+        XCTAssertTrue(wasCalled)
+    }
+    
+    func testPostJSONSuccessWaitsForTheResponseIfDispatchSynchronousIsTrue() {
+        let response = jsonString(withJsonDict: successDict)
+        let session = DelayedRequestKitURLTestSession(response: response, statusCode: 200)
+        var wasCalled = false
+        _ = TestInterface().postJSON(session, synchronousDispatch: true) { response in
+            switch response {
+            case .success:
+                wasCalled = true
+            case .failure:
+                XCTFail("Should not retrieve a failure response")
+            }
+        }
+        XCTAssertTrue(wasCalled)
+    }
+    
+    func testPostJSONSuccessDoesntWaitsForTheResponseIfDispatchSynchronousIsFalse() {
+        let response = jsonString(withJsonDict: successDict)
+        let session = DelayedRequestKitURLTestSession(response: response, statusCode: 200)
+        var wasCalled = false
+        let expectation = XCTestExpectation(description: "Session expectation")
+        
+        _ = TestInterface().postJSON(session, synchronousDispatch: false) { response in
+            switch response {
+            case .success:
+                wasCalled = true
+                expectation.fulfill()
+            case .failure:
+                XCTFail("Should not retrieve a failure response")
+            }
+        }
+        
+        XCTAssertFalse(wasCalled)
+        wait(for: [expectation], timeout: 1)
+        XCTAssertTrue(wasCalled)
+    }
+    
+    private var failureDict = ["message": "Bad credentials", "documentation_url": "https://developer.github.com/v3"]
+    private var successDict = ["message": "Data", "documentation_url": "https://developer.github.com/v3"]
+    private func jsonString(withJsonDict jsonDict: [String : String]) -> String? {
+        return String(data: try! JSONSerialization.data(withJSONObject: jsonDict, options: JSONSerialization.WritingOptions()), encoding: String.Encoding.utf8)
+    }
+}

--- a/Tests/RequestKitTests/RequestKitURLTestSession.swift
+++ b/Tests/RequestKitTests/RequestKitURLTestSession.swift
@@ -74,13 +74,11 @@ final class DelayedRequestKitURLTestSession: RequestKitURLSession {
         self.statusCode = statusCode
     }
     
-    func dataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Swift.Void) -> URLSessionDataTaskProtocol {
+    func dataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTaskProtocol {
         let response = generateResponse(forRequest: request, statusCode: statusCode)
         let data = responseString?.data(using: String.Encoding.utf8)
         
-        DispatchQueue.global(qos: .userInteractive).asyncAfter(deadline: .now() + 0.1) {
-            completionHandler(data, response, nil)
-        }
+        dispatchCompletion(data: data, response: response, completionHandler: completionHandler)
         
         return MockURLSessionDataTask()
     }
@@ -89,11 +87,15 @@ final class DelayedRequestKitURLTestSession: RequestKitURLSession {
         let data = responseString?.data(using: String.Encoding.utf8)
         let response = HTTPURLResponse(url: request.url!, statusCode: statusCode, httpVersion: "http/1.1", headerFields: ["Content-Type": "application/json"])
         
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-            completionHandler(data, response, nil)
-        }
+        dispatchCompletion(data: data, response: response, completionHandler: completionHandler)
         
         return MockURLSessionDataTask()
+    }
+    
+    private func dispatchCompletion(data: Data?, response: HTTPURLResponse?, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) {
+        DispatchQueue.global(qos: .userInteractive).asyncAfter(deadline: .now() + 0.1) {
+            completionHandler(data, response, nil)
+        }
     }
 }
 

--- a/Tests/RequestKitTests/RequestKitURLTestSession.swift
+++ b/Tests/RequestKitTests/RequestKitURLTestSession.swift
@@ -38,7 +38,7 @@ class RequestKitURLTestSession: RequestKitURLSession {
         XCTAssertEqual(request.url?.absoluteString, expectedURL)
         XCTAssertEqual(request.httpMethod, expectedHTTPMethod)
         let data = responseString?.data(using: String.Encoding.utf8)
-        let response = HTTPURLResponse(url: request.url!, statusCode: statusCode, httpVersion: "http/1.1", headerFields: ["Content-Type": "application/json"])
+        let response = generateResponse(forRequest: request, statusCode: statusCode)
         completionHandler(data, response, nil)
         wasCalled = true
         return MockURLSessionDataTask()
@@ -48,9 +48,55 @@ class RequestKitURLTestSession: RequestKitURLSession {
         XCTAssertEqual(request.url?.absoluteString, expectedURL)
         XCTAssertEqual(request.httpMethod, expectedHTTPMethod)
         let data = responseString?.data(using: String.Encoding.utf8)
-        let response = HTTPURLResponse(url: request.url!, statusCode: statusCode, httpVersion: "http/1.1", headerFields: ["Content-Type": "application/json"])
+        let response = generateResponse(forRequest: request, statusCode: statusCode)
         completionHandler(data, response, nil)
         wasCalled = true
         return MockURLSessionDataTask()
     }
+}
+
+
+final class DelayedRequestKitURLTestSession: RequestKitURLSession {
+    let responseString: String?
+    let statusCode: Int
+    
+    init(response: String?, statusCode: Int) {
+        self.responseString = response
+        self.statusCode = statusCode
+    }
+    
+    init(jsonFile: String?, statusCode: Int) {
+        if let jsonFile = jsonFile {
+            self.responseString = Helper.stringFromFile(jsonFile)
+        } else {
+            self.responseString = nil
+        }
+        self.statusCode = statusCode
+    }
+    
+    func dataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Swift.Void) -> URLSessionDataTaskProtocol {
+        let response = generateResponse(forRequest: request, statusCode: statusCode)
+        let data = responseString?.data(using: String.Encoding.utf8)
+        
+        DispatchQueue.global(qos: .userInteractive).asyncAfter(deadline: .now() + 0.1) {
+            completionHandler(data, response, nil)
+        }
+        
+        return MockURLSessionDataTask()
+    }
+    
+    func uploadTask(with request: URLRequest, fromData bodyData: Data?, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTaskProtocol {
+        let data = responseString?.data(using: String.Encoding.utf8)
+        let response = HTTPURLResponse(url: request.url!, statusCode: statusCode, httpVersion: "http/1.1", headerFields: ["Content-Type": "application/json"])
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            completionHandler(data, response, nil)
+        }
+        
+        return MockURLSessionDataTask()
+    }
+}
+
+fileprivate func generateResponse(forRequest request: URLRequest, statusCode: Int) -> HTTPURLResponse? {
+    return HTTPURLResponse(url: request.url!, statusCode: statusCode, httpVersion: "http/1.1", headerFields: ["Content-Type": "application/json"])
 }

--- a/Tests/RequestKitTests/RouterSynchronousDispatchTests.swift
+++ b/Tests/RequestKitTests/RouterSynchronousDispatchTests.swift
@@ -129,10 +129,10 @@ final class RouterSynchronousDispatchTests: XCTestCase {
         XCTAssertTrue(wasCalled)
     }
     
-    fileprivate var failureDict = ["message": "Bad credentials", "documentation_url": "https://developer.github.com/v3"]
-    fileprivate var successDict = ["message": "Data", "documentation_url": "https://developer.github.com/v3"]
+    private var failureDict = ["message": "Bad credentials", "documentation_url": "https://developer.github.com/v3"]
+    private var successDict = ["message": "Data", "documentation_url": "https://developer.github.com/v3"]
     
-    fileprivate func jsonString(withJsonDict jsonDict: [String : String]) -> String? {
+    private func jsonString(withJsonDict jsonDict: [String : String]) -> String? {
         return String(data: try! JSONSerialization.data(withJSONObject: jsonDict, options: JSONSerialization.WritingOptions()), encoding: String.Encoding.utf8)
     }
 }

--- a/Tests/RequestKitTests/RouterSynchronousDispatchTests.swift
+++ b/Tests/RequestKitTests/RouterSynchronousDispatchTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 
 final class RouterSynchronousDispatchTests: XCTestCase {
+#if !os(Linux)
     static var allTests = [
         ("testErrorWithJSONWaitsForTheResponseIfDispatchSynchronousIsTrue", testErrorWithJSONWaitsForTheResponseIfDispatchSynchronousIsTrue),
         ("testErrorWithJSONDoesntWaitsForTheResponseIfDispatchSynchronousIsFalse", testErrorWithJSONDoesntWaitsForTheResponseIfDispatchSynchronousIsFalse),
@@ -154,4 +155,5 @@ final class RouterSynchronousDispatchTests: XCTestCase {
     private func jsonString(withJsonDict jsonDict: [String : String]) -> String? {
         return String(data: try! JSONSerialization.data(withJSONObject: jsonDict, options: JSONSerialization.WritingOptions()), encoding: String.Encoding.utf8)
     }
+#endif
 }

--- a/Tests/RequestKitTests/RouterSynchronousDispatchTests.swift
+++ b/Tests/RequestKitTests/RouterSynchronousDispatchTests.swift
@@ -1,0 +1,138 @@
+//
+//  RouterSynchronousDispatchTests.swift
+//  RequestKitTests
+//
+//  Created by Franco on 24/11/2018.
+//  Copyright © 2018 nerdishbynature. All rights reserved.
+//
+
+import XCTest
+
+final class RouterSynchronousDispatchTests: XCTestCase {
+    func testErrorWithJSONWaitsForTheResponseIfDispatchSynchronousIsTrue() {
+        let response = jsonString(withJsonDict: failureDict)
+        let session = DelayedRequestKitURLTestSession(response: response, statusCode: 401)
+        
+        var wasCalled: Bool = false
+        
+        _ = TestInterface().getJSON(session, synchronousDispatch: true) { response in
+            switch response {
+            case .success:
+                XCTAssert(false, "should not retrieve a succesful response")
+            case .failure:
+                wasCalled = true
+            }
+        }
+        XCTAssertTrue(wasCalled)
+    }
+    
+    func testErrorWithJSONDoesntWaitsForTheResponseIfDispatchSynchronousIsFalse() {
+        let response = jsonString(withJsonDict: failureDict)
+        let session = DelayedRequestKitURLTestSession(response: response, statusCode: 401)
+        
+        var wasCalled: Bool = false
+        
+        let expectation = XCTestExpectation(description: "Session expectation")
+        
+        _ = TestInterface().getJSON(session, synchronousDispatch: false) { response in
+            switch response {
+            case .success:
+                XCTFail("should not retrieve a succesful response")
+            case .failure:
+                wasCalled = true
+            }
+            expectation.fulfill()
+        }
+        
+        XCTAssertFalse(wasCalled)
+        wait(for: [expectation], timeout: 1)
+        XCTAssertTrue(wasCalled)
+    }
+    
+    func testSuccessWithJSONWaitsForTheResponseIfDispatchSynchronousIsTrue() {
+        let response = jsonString(withJsonDict: successDict)
+        let session = DelayedRequestKitURLTestSession(response: response, statusCode: 200)
+        
+        var wasCalled: Bool = false
+        
+        _ = TestInterface().getJSON(session, synchronousDispatch: true) { response in
+            switch response {
+            case .success:
+                wasCalled = true
+            case .failure:
+                XCTFail("should not retrieve a failure response")
+            }
+        }
+        XCTAssertTrue(wasCalled)
+    }
+    
+    func testSuccessWithJSONDoesntWaitsForTheResponseIfDispatchSynchronousIsFalse() {
+        let response = jsonString(withJsonDict: successDict)
+        let session = DelayedRequestKitURLTestSession(response: response, statusCode: 200)
+        
+        var wasCalled: Bool = false
+        
+        let expectation = XCTestExpectation(description: "Session expectation")
+        
+        _ = TestInterface().getJSON(session, synchronousDispatch: false) { response in
+            switch response {
+            case .success:
+                wasCalled = true
+            case .failure:
+                XCTFail("should not retrieve a failure response")
+            }
+            expectation.fulfill()
+        }
+        
+        XCTAssertFalse(wasCalled)
+        wait(for: [expectation], timeout: 1)
+        XCTAssertTrue(wasCalled)
+    }
+    
+    func testSuccessWithLoadAndIgnoreResponseWaitsForTheResponseIfDispatchSynchronousIsTrue() {
+        let response = jsonString(withJsonDict: successDict)
+        let session = DelayedRequestKitURLTestSession(response: response, statusCode: 200)
+        
+        var wasCalled: Bool = false
+        
+        _ = TestInterface().loadAndIgnoreResponseBody(session, synchronousDispatch: true) { response in
+            switch response {
+            case .success:
+                wasCalled = true
+            case .failure:
+                XCTFail("should not retrieve a failure response")
+            }
+        }
+        XCTAssertTrue(wasCalled)
+    }
+    
+    func testSuccessWithLoadAndIgnoreResponseDoesntWaitsForTheResponseIfDispatchSynchronousIsFalse() {
+        let response = jsonString(withJsonDict: successDict)
+        let session = DelayedRequestKitURLTestSession(response: response, statusCode: 200)
+        
+        var wasCalled: Bool = false
+        
+        let expectation = XCTestExpectation(description: "Session expectation")
+        
+        _ = TestInterface().loadAndIgnoreResponseBody(session, synchronousDispatch: false) { response in
+            switch response {
+            case .success:
+                wasCalled = true
+            case .failure:
+                XCTFail("should not retrieve a failure response")
+            }
+            expectation.fulfill()
+        }
+        
+        XCTAssertFalse(wasCalled)
+        wait(for: [expectation], timeout: 1)
+        XCTAssertTrue(wasCalled)
+    }
+    
+    fileprivate var failureDict = ["message": "Bad credentials", "documentation_url": "https://developer.github.com/v3"]
+    fileprivate var successDict = ["message": "Data", "documentation_url": "https://developer.github.com/v3"]
+    
+    fileprivate func jsonString(withJsonDict jsonDict: [String : String]) -> String? {
+        return String(data: try! JSONSerialization.data(withJSONObject: jsonDict, options: JSONSerialization.WritingOptions()), encoding: String.Encoding.utf8)
+    }
+}

--- a/Tests/RequestKitTests/RouterSynchronousDispatchTests.swift
+++ b/Tests/RequestKitTests/RouterSynchronousDispatchTests.swift
@@ -9,6 +9,25 @@
 import XCTest
 
 final class RouterSynchronousDispatchTests: XCTestCase {
+    static var allTests = [
+        ("testErrorWithJSONWaitsForTheResponseIfDispatchSynchronousIsTrue", testErrorWithJSONWaitsForTheResponseIfDispatchSynchronousIsTrue),
+        ("testErrorWithJSONDoesntWaitsForTheResponseIfDispatchSynchronousIsFalse", testErrorWithJSONDoesntWaitsForTheResponseIfDispatchSynchronousIsFalse),
+        ("testSuccessWithJSONWaitsForTheResponseIfDispatchSynchronousIsTrue", testSuccessWithJSONWaitsForTheResponseIfDispatchSynchronousIsTrue),
+        ("testSuccessWithJSONDoesntWaitsForTheResponseIfDispatchSynchronousIsFalse", testSuccessWithJSONDoesntWaitsForTheResponseIfDispatchSynchronousIsFalse),
+        ("testSuccessWithLoadAndIgnoreResponseWaitsForTheResponseIfDispatchSynchronousIsTrue",testSuccessWithLoadAndIgnoreResponseWaitsForTheResponseIfDispatchSynchronousIsTrue),
+        ("testSuccessWithLoadAndIgnoreResponseDoesntWaitsForTheResponseIfDispatchSynchronousIsFalse", testSuccessWithLoadAndIgnoreResponseDoesntWaitsForTheResponseIfDispatchSynchronousIsFalse),
+        ("testLinuxTestSuiteIncludesAllTests", testLinuxTestSuiteIncludesAllTests)
+    ]
+    
+    func testLinuxTestSuiteIncludesAllTests() {
+        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+        let thisClass = type(of: self)
+        let linuxCount = thisClass.allTests.count
+        let darwinCount = thisClass.defaultTestSuite.tests.count
+        XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from allTests")
+        #endif
+    }
+    
     func testErrorWithJSONWaitsForTheResponseIfDispatchSynchronousIsTrue() {
         let response = jsonString(withJsonDict: failureDict)
         let session = DelayedRequestKitURLTestSession(response: response, statusCode: 401)

--- a/Tests/RequestKitTests/TestInterface.swift
+++ b/Tests/RequestKitTests/TestInterface.swift
@@ -15,8 +15,8 @@ class TestInterface {
         return TestInterfaceConfiguration(url: "https://example.com")
     }
 
-    func postJSON(_ session: RequestKitURLSession, completion: @escaping (_ response: Response<[String: AnyObject]>) -> Void) -> URLSessionDataTaskProtocol? {
-        let router = JSONTestRouter.testPOST(configuration)
+    func postJSON(_ session: RequestKitURLSession, synchronousDispatch: Bool = false, completion: @escaping (_ response: Response<[String: AnyObject]>) -> Void) -> URLSessionDataTaskProtocol? {
+        let router = JSONTestRouter.testPOST(configuration, synchronousDispatch)
         return router.postJSON(session, expectedResultType: [String: AnyObject].self) { json, error in
             if let error = error {
                 completion(Response.failure(error))
@@ -28,8 +28,8 @@ class TestInterface {
         }
     }
 
-    func getJSON(_ session: RequestKitURLSession, completion: @escaping (_ response: Response<[String: String]>) -> Void) -> URLSessionDataTaskProtocol? {
-        let router = JSONTestRouter.testGET(configuration)
+    func getJSON(_ session: RequestKitURLSession, synchronousDispatch: Bool = false,  completion: @escaping (_ response: Response<[String: String]>) -> Void) -> URLSessionDataTaskProtocol? {
+        let router = JSONTestRouter.testGET(configuration, synchronousDispatch)
         return router.load(session, expectedResultType: [String: String].self) { json, error in
             if let error = error {
                 completion(Response.failure(error))
@@ -41,8 +41,8 @@ class TestInterface {
         }
     }
     
-    func loadAndIgnoreResponseBody(_ session: RequestKitURLSession, completion: @escaping (_ response: Response<Void>) -> Void) -> URLSessionDataTaskProtocol? {
-        let router = JSONTestRouter.testPOST(configuration)
+    func loadAndIgnoreResponseBody(_ session: RequestKitURLSession, synchronousDispatch: Bool = false, completion: @escaping (_ response: Response<Void>) -> Void) -> URLSessionDataTaskProtocol? {
+        let router = JSONTestRouter.testPOST(configuration, synchronousDispatch)
         return router.load(session) { error in
             if let error = error {
                 completion(Response.failure(error))
@@ -54,13 +54,20 @@ class TestInterface {
 }
 
 enum JSONTestRouter: JSONPostRouter {
-    case testPOST(Configuration)
-    case testGET(Configuration)
-
+    case testPOST(Configuration, Bool)
+    case testGET(Configuration, Bool)
+    
     var configuration: Configuration {
         switch self {
-        case .testPOST(let config): return config
-        case .testGET(let config): return config
+        case .testPOST(let config, _): return config
+        case .testGET(let config, _): return config
+        }
+    }
+    
+    var synchronousDispatch: Bool {
+        switch self {
+        case .testPOST(_, let synchronousDispatch): return synchronousDispatch
+        case .testGET(_, let synchronousDispatch): return synchronousDispatch
         }
     }
 


### PR DESCRIPTION
CLI apps on swift doesn't have runloop, this makes more complicated for them wait for the result of the async operations.
Danger-swift is one of them.
If you look at https://github.com/danger/swift/blob/master/Dangerfile.swift#L23, it gets never called, because the Dangerfile execution finishes before the completion block gets called.
This PR introduces the variable synchronousDispatch on the router protocol.
It allows you to wait for the response of the call.
It it set by default to false, to avoid breaking changes.