### PR TITLE
Enable async/await on macOS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,9 +11,9 @@ on:
 jobs:
   macOS:
     name: Test macOS
-    runs-on: macOS-11
+    runs-on: macOS-latest
     env:
-      DEVELOPER_DIR: /Applications/Xcode_13.0.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_13.2.1.app/Contents/Developer
     strategy:
       matrix:
         include:

--- a/Sources/RequestKit/JSONPostRouter.swift
+++ b/Sources/RequestKit/JSONPostRouter.swift
@@ -7,7 +7,7 @@ public protocol JSONPostRouter: Router {
     func postJSON<T>(_ session: RequestKitURLSession, expectedResultType: T.Type, completion: @escaping (_ json: T?, _ error: Error?) -> Void) -> URLSessionDataTaskProtocol?
     func post<T: Codable>(_ session: RequestKitURLSession, decoder: JSONDecoder, expectedResultType: T.Type, completion: @escaping (_ json: T?, _ error: Error?) -> Void) -> URLSessionDataTaskProtocol?
 
-    #if !canImport(FoundationNetworking) && !os(macOS)
+    #if !canImport(FoundationNetworking)
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func postJSON<T>(_ session: RequestKitURLSession, expectedResultType: T.Type) async throws -> T?
     
@@ -62,7 +62,7 @@ public extension JSONPostRouter {
         return task
     }
 
-    #if !canImport(FoundationNetworking) && !os(macOS)
+    #if !canImport(FoundationNetworking)
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func postJSON<T>(_ session: RequestKitURLSession = URLSession.shared, expectedResultType: T.Type) async throws -> T? {
         guard let request = request() else {
@@ -130,7 +130,7 @@ public extension JSONPostRouter {
         return task
     }
 
-    #if !canImport(FoundationNetworking) && !os(macOS) && !os(macOS)
+    #if !canImport(FoundationNetworking)
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func post<T: Codable>(_ session: RequestKitURLSession, decoder: JSONDecoder = JSONDecoder(), expectedResultType: T.Type) async throws -> T {
         guard let request = request() else {

--- a/Sources/RequestKit/RequestKitSession.swift
+++ b/Sources/RequestKit/RequestKitSession.swift
@@ -7,7 +7,7 @@ public protocol RequestKitURLSession {
     func dataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Swift.Void) -> URLSessionDataTaskProtocol
     func uploadTask(with request: URLRequest, fromData bodyData: Data?, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTaskProtocol
 
-    #if !canImport(FoundationNetworking) && !os(macOS)
+    #if !canImport(FoundationNetworking)
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func data(for request: URLRequest, delegate: URLSessionTaskDelegate?) async throws -> (Data, URLResponse)
     

--- a/Sources/RequestKit/Router.swift
+++ b/Sources/RequestKit/Router.swift
@@ -187,7 +187,7 @@ public extension Router {
         return task
     }
 
-    #if !canImport(FoundationNetworking) && !os(macOS)
+    #if !canImport(FoundationNetworking)
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func load<T: Codable>(_ session: RequestKitURLSession = URLSession.shared, decoder: JSONDecoder = JSONDecoder(), expectedResultType: T.Type) async throws -> T {
         guard let request = request() else {

--- a/Tests/RequestKitTests/JSONPostRouterTests.swift
+++ b/Tests/RequestKitTests/JSONPostRouterTests.swift
@@ -21,7 +21,7 @@ class JSONPostRouterTests: XCTestCase {
         XCTAssertTrue(session.wasCalled)
     }
 
-    #if !canImport(FoundationNetworking) && !os(macOS)
+    #if !canImport(FoundationNetworking)
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func testJSONPostJSONErrorAsync() async throws {
         let jsonDict = ["message": "Bad credentials", "documentation_url": "https://developer.github.com/v3"]
@@ -56,7 +56,7 @@ class JSONPostRouterTests: XCTestCase {
         XCTAssertTrue(session.wasCalled)
     }
     
-    #if !canImport(FoundationNetworking) && !os(macOS)
+    #if !canImport(FoundationNetworking)
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func testJSONPostStringErrorAsync() async throws {
         let errorString = "Just nope"

--- a/Tests/RequestKitTests/RequestKitURLTestSession.swift
+++ b/Tests/RequestKitTests/RequestKitURLTestSession.swift
@@ -57,7 +57,7 @@ class RequestKitURLTestSession: RequestKitURLSession {
         return MockURLSessionDataTask()
     }
 
-    #if !canImport(FoundationNetworking) && !os(macOS)
+    #if !canImport(FoundationNetworking)
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func upload(for request: URLRequest, from data: Data, delegate: URLSessionTaskDelegate?) async throws -> (Data, URLResponse) {
         XCTAssertEqual(request.url?.absoluteString, expectedURL)

--- a/Tests/RequestKitTests/RouterTests.swift
+++ b/Tests/RequestKitTests/RouterTests.swift
@@ -84,7 +84,7 @@ class RouterTests: XCTestCase {
         XCTAssertTrue(session.wasCalled)
     }
 
-    #if !canImport(FoundationNetworking) && !os(macOS)
+    #if !canImport(FoundationNetworking)
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func testErrorWithJSONAsync() async throws {
         let jsonDict = ["message": "Bad credentials", "documentation_url": "https://developer.github.com/v3"]

--- a/Tests/RequestKitTests/TestInterface.swift
+++ b/Tests/RequestKitTests/TestInterface.swift
@@ -28,7 +28,7 @@ class TestInterface {
         }
     }
 
-    #if !canImport(FoundationNetworking) && !os(macOS)
+    #if !canImport(FoundationNetworking)
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func postJSON(_ session: RequestKitURLSession) async throws -> [String: AnyObject]? {
         let router = JSONTestRouter.testPOST(configuration)
@@ -49,7 +49,7 @@ class TestInterface {
         }
     }
 
-    #if !canImport(FoundationNetworking) && !os(macOS)
+    #if !canImport(FoundationNetworking)
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func getJSON(_ session: RequestKitURLSession) async throws -> [String: String] {
         let router = JSONTestRouter.testGET(configuration)

--- a/fastlane/.env.default
+++ b/fastlane/.env.default
@@ -1,6 +1,6 @@
-AF_IOS_SDK=iphonesimulator15.0
-AF_MAC_SDK=macosx12.0
-AF_TVOS_SDK=appletvsimulator15.0
+AF_IOS_SDK=iphonesimulator15.2
+AF_MAC_SDK=macosx12.2
+AF_TVOS_SDK=appletvsimulator15.2
 
 AF_CONFIGURATION=Release
 

--- a/fastlane/.env.ios
+++ b/fastlane/.env.ios
@@ -1,2 +1,2 @@
 SCAN_DEVICE="iPhone 12 Pro"
-SCAN_SDK=iphonesimulator15.0
+SCAN_SDK=$AF_IOS_SDK


### PR DESCRIPTION
Since macOS 12 was released we can now also enable async/await on this platform.