### PR TITLE
gh:workflows: add swiftformat as a lint step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,3 +42,14 @@ jobs:
       - uses: actions/checkout@v2
       - name: SPM Test
         run: swift test --enable-test-discovery
+  swiftformat:
+    name: Lint
+    runs-on: macOS-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install
+        run: |
+          brew install swiftformat
+      - name: Lint
+        run: |
+          swiftformat --lint .


### PR DESCRIPTION
This is linked to https://github.com/nerdishbynature/RequestKit/pull/79

CI [job](https://github.com/nerdishbynature/RequestKit/runs/4709581868?check_suite_focus=true) fails: 
![Screenshot](https://user-images.githubusercontent.com/211000/148147431-67e866df-d6ce-4cd8-be35-35083ed996f2.png)
