### PR TITLE
Add capability to setup request tracing

### DIFF
--- a/RequestKit.xcodeproj/project.pbxproj
+++ b/RequestKit.xcodeproj/project.pbxproj
@@ -44,6 +44,13 @@
 		7679C02320AB08290052BBDC /* TestInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7679C00C20AB08290052BBDC /* TestInterface.swift */; };
 		7679C02420AB08290052BBDC /* TestInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7679C00C20AB08290052BBDC /* TestInterface.swift */; };
 		7679C02520AB08290052BBDC /* TestInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7679C00C20AB08290052BBDC /* TestInterface.swift */; };
+		A8ABFA372788F94E00B3FA7A /* Tracer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8ABFA362788F94E00B3FA7A /* Tracer.swift */; };
+		A8ABFA382788F94E00B3FA7A /* Tracer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8ABFA362788F94E00B3FA7A /* Tracer.swift */; };
+		A8ABFA392788F94E00B3FA7A /* Tracer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8ABFA362788F94E00B3FA7A /* Tracer.swift */; };
+		A8ABFA3A2788F94E00B3FA7A /* Tracer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8ABFA362788F94E00B3FA7A /* Tracer.swift */; };
+		A8ABFA3B2788F94E00B3FA7A /* Tracer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8ABFA362788F94E00B3FA7A /* Tracer.swift */; };
+		A8ABFA3C2788F94E00B3FA7A /* Tracer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8ABFA362788F94E00B3FA7A /* Tracer.swift */; };
+		A8ABFA3D2788F94E00B3FA7A /* Tracer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8ABFA362788F94E00B3FA7A /* Tracer.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -90,6 +97,7 @@
 		7679C00B20AB08290052BBDC /* JSONPostRouterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONPostRouterTests.swift; sourceTree = "<group>"; };
 		7679C00C20AB08290052BBDC /* TestInterface.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestInterface.swift; sourceTree = "<group>"; };
 		7679C00D20AB08290052BBDC /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		A8ABFA362788F94E00B3FA7A /* Tracer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tracer.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -187,6 +195,7 @@
 				7679BFEA20AB081C0052BBDC /* JSONPostRouter.swift */,
 				7679BFEC20AB081C0052BBDC /* RequestKitSession.swift */,
 				7679BFEE20AB081C0052BBDC /* Info.plist */,
+				A8ABFA362788F94E00B3FA7A /* Tracer.swift */,
 			);
 			path = RequestKit;
 			sourceTree = "<group>";
@@ -377,7 +386,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0720;
-				LastUpgradeCheck = 1300;
+				LastUpgradeCheck = 1320;
 				ORGANIZATIONNAME = nerdishbynature;
 				TargetAttributes = {
 					233742FF1C7981A800013492 = {
@@ -446,6 +455,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A8ABFA392788F94E00B3FA7A /* Tracer.swift in Sources */,
 				7679BFF820AB081C0052BBDC /* RequestKitSession.swift in Sources */,
 				7679BFF020AB081C0052BBDC /* JSONPostRouter.swift in Sources */,
 				7679BFFC20AB081C0052BBDC /* Router.swift in Sources */,
@@ -456,6 +466,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A8ABFA3B2788F94E00B3FA7A /* Tracer.swift in Sources */,
 				7679BFF920AB081C0052BBDC /* RequestKitSession.swift in Sources */,
 				7679BFF120AB081C0052BBDC /* JSONPostRouter.swift in Sources */,
 				7679BFFD20AB081C0052BBDC /* Router.swift in Sources */,
@@ -466,6 +477,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A8ABFA3C2788F94E00B3FA7A /* Tracer.swift in Sources */,
 				7679BFFA20AB081C0052BBDC /* RequestKitSession.swift in Sources */,
 				7679BFF220AB081C0052BBDC /* JSONPostRouter.swift in Sources */,
 				7679BFFE20AB081C0052BBDC /* Router.swift in Sources */,
@@ -478,6 +490,7 @@
 			files = (
 				7679C01C20AB08290052BBDC /* ConfigurationTests.swift in Sources */,
 				7679C01320AB08290052BBDC /* RequestKitURLTestSession.swift in Sources */,
+				A8ABFA3D2788F94E00B3FA7A /* Tracer.swift in Sources */,
 				7679C02520AB08290052BBDC /* TestInterface.swift in Sources */,
 				7679C01F20AB08290052BBDC /* TestHelper.swift in Sources */,
 				7679C02220AB08290052BBDC /* JSONPostRouterTests.swift in Sources */,
@@ -491,6 +504,7 @@
 			files = (
 				7679C01B20AB08290052BBDC /* ConfigurationTests.swift in Sources */,
 				7679C01220AB08290052BBDC /* RequestKitURLTestSession.swift in Sources */,
+				A8ABFA3A2788F94E00B3FA7A /* Tracer.swift in Sources */,
 				7679C02420AB08290052BBDC /* TestInterface.swift in Sources */,
 				7679C01E20AB08290052BBDC /* TestHelper.swift in Sources */,
 				7679C02120AB08290052BBDC /* JSONPostRouterTests.swift in Sources */,
@@ -502,6 +516,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A8ABFA372788F94E00B3FA7A /* Tracer.swift in Sources */,
 				7679BFF720AB081C0052BBDC /* RequestKitSession.swift in Sources */,
 				7679BFEF20AB081C0052BBDC /* JSONPostRouter.swift in Sources */,
 				7679BFFB20AB081C0052BBDC /* Router.swift in Sources */,
@@ -514,6 +529,7 @@
 			files = (
 				7679C01A20AB08290052BBDC /* ConfigurationTests.swift in Sources */,
 				7679C01120AB08290052BBDC /* RequestKitURLTestSession.swift in Sources */,
+				A8ABFA382788F94E00B3FA7A /* Tracer.swift in Sources */,
 				7679C02320AB08290052BBDC /* TestInterface.swift in Sources */,
 				7679C01D20AB08290052BBDC /* TestHelper.swift in Sources */,
 				7679C02020AB08290052BBDC /* JSONPostRouterTests.swift in Sources */,
@@ -557,7 +573,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 9.0;
+				TVOS_DEPLOYMENT_TARGET = 12.0;
 			};
 			name = Debug;
 		};
@@ -576,7 +592,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 9.0;
+				TVOS_DEPLOYMENT_TARGET = 12.0;
 			};
 			name = Release;
 		};
@@ -765,7 +781,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INFOPLIST_FILE = Sources/RequestKit/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.nerdishbynature.RequestKit;
@@ -823,7 +839,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INFOPLIST_FILE = Sources/RequestKit/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.nerdishbynature.RequestKit;
 				PRODUCT_NAME = RequestKit;

--- a/RequestKit.xcodeproj/xcshareddata/xcschemes/RequestKit Mac.xcscheme
+++ b/RequestKit.xcodeproj/xcshareddata/xcschemes/RequestKit Mac.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1320"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/RequestKit.xcodeproj/xcshareddata/xcschemes/RequestKit tvOS.xcscheme
+++ b/RequestKit.xcodeproj/xcshareddata/xcschemes/RequestKit tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1320"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/RequestKit.xcodeproj/xcshareddata/xcschemes/RequestKit watchOS.xcscheme
+++ b/RequestKit.xcodeproj/xcshareddata/xcschemes/RequestKit watchOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1320"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/RequestKit.xcodeproj/xcshareddata/xcschemes/RequestKit.xcscheme
+++ b/RequestKit.xcodeproj/xcshareddata/xcschemes/RequestKit.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1320"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Sources/RequestKit/Router.swift
+++ b/Sources/RequestKit/Router.swift
@@ -27,6 +27,7 @@ public protocol Configuration {
     var authorizationHeader: String? { get }
     var errorDomain: String { get }
     var customHeaders: [HTTPHeader]? { get }
+    var tracerConfiguration: TracerConfiguration? { get }
 }
 
 public extension Configuration {
@@ -43,6 +44,10 @@ public extension Configuration {
     }
 
     var customHeaders: [HTTPHeader]? {
+        return nil
+    }
+
+    var tracerConfiguration: TracerConfiguration? {
         return nil
     }
 }
@@ -164,7 +169,10 @@ public extension Router {
             return nil
         }
 
+        let tracer = Tracer(configuration.tracerConfiguration)
+        tracer.before(request)
         let task = session.dataTask(with: request) { data, response, err in
+            tracer.after(request, data, response, err)
             if let response = response as? HTTPURLResponse {
                 if response.wasSuccessful == false {
                     var userInfo = [String: Any]()
@@ -231,7 +239,10 @@ public extension Router {
             return nil
         }
 
+        let tracer = Tracer(configuration.tracerConfiguration)
+        tracer.before(request)
         let task = session.dataTask(with: request) { data, response, err in
+            tracer.after(request, data, response, err)
             if let response = response as? HTTPURLResponse {
                 if response.wasSuccessful == false {
                     var userInfo = [String: Any]()

--- a/Sources/RequestKit/Tracer.swift
+++ b/Sources/RequestKit/Tracer.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 public enum TracerOption: Int {
     case RequestHeaders, RequestBody, ResponseHeaders, ResponseBody

--- a/Sources/RequestKit/Tracer.swift
+++ b/Sources/RequestKit/Tracer.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+public enum TracerOption: Int {
+    case RequestHeaders, RequestBody, ResponseHeaders, ResponseBody
+}
+
+public typealias TracerConfiguration = Set<TracerOption>
+
+public class Tracer {
+    var configuration: TracerConfiguration?
+
+    init(_ configuration: TracerConfiguration?) {
+        self.configuration = configuration
+    }
+
+    func preambule(_ request: URLRequest) -> String {
+        let df = DateFormatter()
+        df.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        return "\(df.string(from: Date())) / \(String(format: "%0X", request.hashValue)): "
+    }
+
+    func before(_ request: URLRequest) {
+        guard let configuration = configuration else { return }
+        let preambule = preambule(request)
+        print(preambule, "URL \(request.url ?? URL(fileURLWithPath: "?"))")
+        if configuration.contains(.RequestHeaders), let headers = request.allHTTPHeaderFields {
+            for (k, v) in headers {
+                print(preambule, "Request header: \(k) -> \(v)")
+            }
+        }
+    }
+
+    func after(_ request: URLRequest, _ data: Data?, _ response: URLResponse?, _ err: Error?) {
+        guard let configuration = configuration else { return }
+        let preambule = preambule(request)
+        if let err = err {
+            print(preambule, "Error \(err)")
+        }
+        if let response = response as? HTTPURLResponse {
+            if configuration.contains(.ResponseHeaders) {
+                for (k, v) in response.allHeaderFields {
+                    print(preambule, "Response header: \(k) -> \(v)")
+                }
+            }
+        }
+        if configuration.contains(.ResponseBody), let data = data {
+            print(preambule, "Data \(data)")
+        }
+    }
+}

--- a/Sources/RequestKit/Tracer.swift
+++ b/Sources/RequestKit/Tracer.swift
@@ -24,7 +24,9 @@ public class Tracer {
         let preambule = preambule(request)
         print(preambule, "URL \(request.url ?? URL(fileURLWithPath: "?"))")
         if configuration.contains(.RequestHeaders), let headers = request.allHTTPHeaderFields {
-            for (k, v) in headers {
+            for (k, v) in headers.sorted(by: {
+                $0.key.caseInsensitiveCompare($1.key) == .orderedAscending
+            }) {
                 print(preambule, "Request header: \(k) -> \(v)")
             }
         }
@@ -38,7 +40,11 @@ public class Tracer {
         }
         if let response = response as? HTTPURLResponse {
             if configuration.contains(.ResponseHeaders) {
-                for (k, v) in response.allHeaderFields {
+                for (k, v) in response.allHeaderFields.sorted(by: {
+                    let a = $0.key as? String ?? ""
+                    let b = $1.key as? String ?? ""
+                    return a.caseInsensitiveCompare(b) == .orderedAscending
+                }) {
                     print(preambule, "Response header: \(k) -> \(v)")
                 }
             }


### PR DESCRIPTION
Example output:
```
2022-01-07 19:28:22 / E5F8826D:  URL https://api.github.com/notifications?all=false&page=1&participating=true&per_page=20
2022-01-07 19:28:22 / E5F8826D:  Request header: Authorization -> token foobarfoobar
2022-01-07 19:28:22 / E5F8826D:  Request header: Cache-Control -> no-cache
2022-01-07 19:28:22 / E5F8826D:  Response header: Access-Control-Allow-Origin -> Optional("*")
2022-01-07 19:28:22 / E5F8826D:  Response header: access-control-expose-headers -> Optional("ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset")
2022-01-07 19:28:22 / E5F8826D:  Response header: Cache-Control -> Optional("private, max-age=60, s-maxage=60")
2022-01-07 19:28:22 / E5F8826D:  Response header: Content-Encoding -> Optional("gzip")
2022-01-07 19:28:22 / E5F8826D:  Response header: content-security-policy -> Optional("default-src \'none\'")
2022-01-07 19:28:22 / E5F8826D:  Response header: Content-Type -> Optional("application/json; charset=utf-8")
2022-01-07 19:28:22 / E5F8826D:  Response header: Date -> Optional("Fri, 07 Jan 2022 18:28:22 GMT")
2022-01-07 19:28:22 / E5F8826D:  Response header: Etag -> Optional("W/\"\"")
2022-01-07 19:28:22 / E5F8826D:  Response header: Last-Modified -> Optional("Fri, 07 Jan 2022 18:23:15 GMT")
2022-01-07 19:28:22 / E5F8826D:  Response header: referrer-policy -> Optional("origin-when-cross-origin, strict-origin-when-cross-origin")
2022-01-07 19:28:22 / E5F8826D:  Response header: Server -> Optional("GitHub.com")
```