### PR TITLE
Enable async/await on Linux

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,12 +37,19 @@ jobs:
   spm:
     name: Test with SPM
     runs-on: ubuntu-latest
+    container: swift:5.5-focal
+    steps:
+      - uses: actions/checkout@v2
+      - name: SPM Test
+        run: swift test --enable-test-discovery
+  spm_concurrency:
+    name: Test with SPM (check Swift Concurrency support)
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         swift_version:
           - 5.5.1
           - 5.5.2
-          - 5.5.3
       fail-fast: false
     container: swift:${{ matrix.swift_version }}-focal
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,14 @@ jobs:
   spm:
     name: Test with SPM
     runs-on: ubuntu-latest
-    container: swift:5.5-focal
+    strategy:
+      matrix:
+        swift_version:
+          - 5.5.1
+          - 5.5.2
+          - 5.5.3
+      fail-fast: false
+    container: swift:${{ matrix.swift_version }}-focal
     steps:
       - uses: actions/checkout@v2
       - name: SPM Test

--- a/Sources/RequestKit/JSONPostRouter.swift
+++ b/Sources/RequestKit/JSONPostRouter.swift
@@ -7,7 +7,7 @@ public protocol JSONPostRouter: Router {
     func postJSON<T>(_ session: RequestKitURLSession, expectedResultType: T.Type, completion: @escaping (_ json: T?, _ error: Error?) -> Void) -> URLSessionDataTaskProtocol?
     func post<T: Codable>(_ session: RequestKitURLSession, decoder: JSONDecoder, expectedResultType: T.Type, completion: @escaping (_ json: T?, _ error: Error?) -> Void) -> URLSessionDataTaskProtocol?
 
-    #if !canImport(FoundationNetworking)
+    #if swift(>=5.5.2)
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func postJSON<T>(_ session: RequestKitURLSession, expectedResultType: T.Type) async throws -> T?
 
@@ -62,7 +62,7 @@ public extension JSONPostRouter {
         return task
     }
 
-    #if !canImport(FoundationNetworking)
+    #if swift(>=5.5.2)
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func postJSON<T>(_ session: RequestKitURLSession = URLSession.shared, expectedResultType _: T.Type) async throws -> T? {
         guard let request = request() else {
@@ -132,7 +132,7 @@ public extension JSONPostRouter {
         return task
     }
 
-    #if !canImport(FoundationNetworking)
+    #if swift(>=5.5.2)
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func post<T: Codable>(_ session: RequestKitURLSession, decoder: JSONDecoder = JSONDecoder(), expectedResultType _: T.Type) async throws -> T {
         guard let request = request() else {

--- a/Sources/RequestKit/JSONPostRouter.swift
+++ b/Sources/RequestKit/JSONPostRouter.swift
@@ -7,7 +7,7 @@ public protocol JSONPostRouter: Router {
     func postJSON<T>(_ session: RequestKitURLSession, expectedResultType: T.Type, completion: @escaping (_ json: T?, _ error: Error?) -> Void) -> URLSessionDataTaskProtocol?
     func post<T: Codable>(_ session: RequestKitURLSession, decoder: JSONDecoder, expectedResultType: T.Type, completion: @escaping (_ json: T?, _ error: Error?) -> Void) -> URLSessionDataTaskProtocol?
 
-    #if swift(>=5.5.2)
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func postJSON<T>(_ session: RequestKitURLSession, expectedResultType: T.Type) async throws -> T?
 
@@ -62,7 +62,7 @@ public extension JSONPostRouter {
         return task
     }
 
-    #if swift(>=5.5.2)
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func postJSON<T>(_ session: RequestKitURLSession = URLSession.shared, expectedResultType _: T.Type) async throws -> T? {
         guard let request = request() else {
@@ -132,7 +132,7 @@ public extension JSONPostRouter {
         return task
     }
 
-    #if swift(>=5.5.2)
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func post<T: Codable>(_ session: RequestKitURLSession, decoder: JSONDecoder = JSONDecoder(), expectedResultType _: T.Type) async throws -> T {
         guard let request = request() else {

--- a/Sources/RequestKit/RequestKitSession.swift
+++ b/Sources/RequestKit/RequestKitSession.swift
@@ -33,7 +33,7 @@ extension URLSession: RequestKitURLSession {
 
     #if compiler(>=5.5.2) && canImport(_Concurrency) && canImport(FoundationNetworking)
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-    public func data(for request: URLRequest, delegate: URLSessionTaskDelegate?) async throws -> (Data, URLResponse) {
+    public func data(for request: URLRequest, delegate _: URLSessionTaskDelegate?) async throws -> (Data, URLResponse) {
         return try await withCheckedThrowingContinuation { continuation in
             let task = dataTask(with: request) { data, response, error in
                 if let error = error {
@@ -48,7 +48,7 @@ extension URLSession: RequestKitURLSession {
     }
 
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-    public func upload(for request: URLRequest, from bodyData: Data, delegate: URLSessionTaskDelegate?) async throws -> (Data, URLResponse) {
+    public func upload(for request: URLRequest, from bodyData: Data, delegate _: URLSessionTaskDelegate?) async throws -> (Data, URLResponse) {
         return try await withCheckedThrowingContinuation { continuation in
             let task = uploadTask(with: request, from: bodyData) { data, response, error in
                 if let error = error {

--- a/Sources/RequestKit/RequestKitSession.swift
+++ b/Sources/RequestKit/RequestKitSession.swift
@@ -7,7 +7,7 @@ public protocol RequestKitURLSession {
     func dataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Swift.Void) -> URLSessionDataTaskProtocol
     func uploadTask(with request: URLRequest, fromData bodyData: Data?, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTaskProtocol
 
-    #if !canImport(FoundationNetworking)
+    #if swift(>=5.5.2)
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func data(for request: URLRequest, delegate: URLSessionTaskDelegate?) async throws -> (Data, URLResponse)
 
@@ -30,4 +30,36 @@ extension URLSession: RequestKitURLSession {
     public func uploadTask(with request: URLRequest, fromData bodyData: Data?, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTaskProtocol {
         return uploadTask(with: request, from: bodyData, completionHandler: completionHandler)
     }
+
+    #if swift(>=5.5.2) && canImport(FoundationNetworking)
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    public func data(for request: URLRequest, delegate: URLSessionTaskDelegate?) async throws -> (Data, URLResponse) {
+        return try await withCheckedThrowingContinuation { continuation in
+            let task = dataTask(with: request) { data, response, error in
+                if let error = error {
+                    continuation.resume(throwing: error)
+                }
+                if let data = data, let response = response {
+                    continuation.resume(returning: (data, response))
+                }
+            } as URLSessionDataTask
+            task.resume()
+        }
+    }
+
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    public func upload(for request: URLRequest, from bodyData: Data, delegate: URLSessionTaskDelegate?) async throws -> (Data, URLResponse) {
+        return try await withCheckedThrowingContinuation { continuation in
+            let task = uploadTask(with: request, from: bodyData) { data, response, error in
+                if let error = error {
+                    continuation.resume(throwing: error)
+                }
+                if let data = data, let response = response {
+                    continuation.resume(returning: (data, response))
+                }
+            }
+            task.resume()
+        }
+    }
+    #endif
 }

--- a/Sources/RequestKit/RequestKitSession.swift
+++ b/Sources/RequestKit/RequestKitSession.swift
@@ -7,7 +7,7 @@ public protocol RequestKitURLSession {
     func dataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Swift.Void) -> URLSessionDataTaskProtocol
     func uploadTask(with request: URLRequest, fromData bodyData: Data?, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTaskProtocol
 
-    #if swift(>=5.5.2)
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func data(for request: URLRequest, delegate: URLSessionTaskDelegate?) async throws -> (Data, URLResponse)
 
@@ -31,7 +31,7 @@ extension URLSession: RequestKitURLSession {
         return uploadTask(with: request, from: bodyData, completionHandler: completionHandler)
     }
 
-    #if swift(>=5.5.2) && canImport(FoundationNetworking)
+    #if compiler(>=5.5.2) && canImport(_Concurrency) && canImport(FoundationNetworking)
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     public func data(for request: URLRequest, delegate: URLSessionTaskDelegate?) async throws -> (Data, URLResponse) {
         return try await withCheckedThrowingContinuation { continuation in

--- a/Sources/RequestKit/Router.swift
+++ b/Sources/RequestKit/Router.swift
@@ -194,7 +194,7 @@ public extension Router {
         return task
     }
 
-    #if swift(>=5.5.2)
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func load<T: Codable>(_ session: RequestKitURLSession = URLSession.shared, decoder: JSONDecoder = JSONDecoder(), expectedResultType _: T.Type) async throws -> T {
         guard let request = request() else {

--- a/Sources/RequestKit/Router.swift
+++ b/Sources/RequestKit/Router.swift
@@ -194,7 +194,7 @@ public extension Router {
         return task
     }
 
-    #if !canImport(FoundationNetworking)
+    #if swift(>=5.5.2)
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func load<T: Codable>(_ session: RequestKitURLSession = URLSession.shared, decoder: JSONDecoder = JSONDecoder(), expectedResultType _: T.Type) async throws -> T {
         guard let request = request() else {

--- a/Tests/RequestKitTests/JSONPostRouterTests.swift
+++ b/Tests/RequestKitTests/JSONPostRouterTests.swift
@@ -21,7 +21,7 @@ class JSONPostRouterTests: XCTestCase {
         XCTAssertTrue(session.wasCalled)
     }
 
-    #if !canImport(FoundationNetworking)
+    #if swift(>=5.5.2)
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func testJSONPostJSONErrorAsync() async throws {
         let jsonDict = ["message": "Bad credentials", "documentation_url": "https://developer.github.com/v3"]
@@ -56,7 +56,7 @@ class JSONPostRouterTests: XCTestCase {
         XCTAssertTrue(session.wasCalled)
     }
 
-    #if !canImport(FoundationNetworking)
+    #if swift(>=5.5.2)
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func testJSONPostStringErrorAsync() async throws {
         let errorString = "Just nope"

--- a/Tests/RequestKitTests/JSONPostRouterTests.swift
+++ b/Tests/RequestKitTests/JSONPostRouterTests.swift
@@ -21,7 +21,7 @@ class JSONPostRouterTests: XCTestCase {
         XCTAssertTrue(session.wasCalled)
     }
 
-    #if swift(>=5.5.2)
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func testJSONPostJSONErrorAsync() async throws {
         let jsonDict = ["message": "Bad credentials", "documentation_url": "https://developer.github.com/v3"]
@@ -56,7 +56,7 @@ class JSONPostRouterTests: XCTestCase {
         XCTAssertTrue(session.wasCalled)
     }
 
-    #if swift(>=5.5.2)
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func testJSONPostStringErrorAsync() async throws {
         let errorString = "Just nope"

--- a/Tests/RequestKitTests/RequestKitURLTestSession.swift
+++ b/Tests/RequestKitTests/RequestKitURLTestSession.swift
@@ -57,7 +57,7 @@ class RequestKitURLTestSession: RequestKitURLSession {
         return MockURLSessionDataTask()
     }
 
-    #if swift(>=5.5.2)
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func upload(for request: URLRequest, from _: Data, delegate _: URLSessionTaskDelegate?) async throws -> (Data, URLResponse) {
         XCTAssertEqual(request.url?.absoluteString, expectedURL)

--- a/Tests/RequestKitTests/RequestKitURLTestSession.swift
+++ b/Tests/RequestKitTests/RequestKitURLTestSession.swift
@@ -57,7 +57,7 @@ class RequestKitURLTestSession: RequestKitURLSession {
         return MockURLSessionDataTask()
     }
 
-    #if !canImport(FoundationNetworking)
+    #if swift(>=5.5.2)
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func upload(for request: URLRequest, from _: Data, delegate _: URLSessionTaskDelegate?) async throws -> (Data, URLResponse) {
         XCTAssertEqual(request.url?.absoluteString, expectedURL)

--- a/Tests/RequestKitTests/RouterTests.swift
+++ b/Tests/RequestKitTests/RouterTests.swift
@@ -84,7 +84,7 @@ class RouterTests: XCTestCase {
         XCTAssertTrue(session.wasCalled)
     }
 
-    #if !canImport(FoundationNetworking)
+    #if swift(>=5.5.2)
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func testErrorWithJSONAsync() async throws {
         let jsonDict = ["message": "Bad credentials", "documentation_url": "https://developer.github.com/v3"]

--- a/Tests/RequestKitTests/RouterTests.swift
+++ b/Tests/RequestKitTests/RouterTests.swift
@@ -84,7 +84,7 @@ class RouterTests: XCTestCase {
         XCTAssertTrue(session.wasCalled)
     }
 
-    #if swift(>=5.5.2)
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func testErrorWithJSONAsync() async throws {
         let jsonDict = ["message": "Bad credentials", "documentation_url": "https://developer.github.com/v3"]

--- a/Tests/RequestKitTests/TestInterface.swift
+++ b/Tests/RequestKitTests/TestInterface.swift
@@ -28,7 +28,7 @@ class TestInterface {
         }
     }
 
-    #if swift(>=5.5.2)
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func postJSON(_ session: RequestKitURLSession) async throws -> [String: AnyObject]? {
         let router = JSONTestRouter.testPOST(configuration)
@@ -49,7 +49,7 @@ class TestInterface {
         }
     }
 
-    #if swift(>=5.5.2)
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func getJSON(_ session: RequestKitURLSession) async throws -> [String: String] {
         let router = JSONTestRouter.testGET(configuration)

--- a/Tests/RequestKitTests/TestInterface.swift
+++ b/Tests/RequestKitTests/TestInterface.swift
@@ -28,7 +28,7 @@ class TestInterface {
         }
     }
 
-    #if !canImport(FoundationNetworking)
+    #if swift(>=5.5.2)
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func postJSON(_ session: RequestKitURLSession) async throws -> [String: AnyObject]? {
         let router = JSONTestRouter.testPOST(configuration)
@@ -49,7 +49,7 @@ class TestInterface {
         }
     }
 
-    #if !canImport(FoundationNetworking)
+    #if swift(>=5.5.2)
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func getJSON(_ session: RequestKitURLSession) async throws -> [String: String] {
         let router = JSONTestRouter.testGET(configuration)


### PR DESCRIPTION
async/await is supported on Linux since Swift 5.5.2.

I fix all conditions for any functions which are using async/await to enable in Linux platform.
New condition refers to [Alamofire](https://github.com/Alamofire/Alamofire/pull/3463/files?w=1#diff-f6f501f698bce66e18904a7fa2f8316ab3ef18461625d0446e0126738f0d0313).

Additionally, I add matrix for testing in Linux to check it passes whether or not it supports Concurrency.