### PR TITLE
`async/await` Void function

### DIFF
--- a/Sources/RequestKit/Router.swift
+++ b/Sources/RequestKit/Router.swift
@@ -63,6 +63,15 @@ public protocol Router {
                           completion: @escaping (_ json: T?, _ error: Error?) -> Void) -> URLSessionDataTaskProtocol?
     func load<T: Codable>(_ session: RequestKitURLSession, decoder: JSONDecoder, expectedResultType: T.Type, completion: @escaping (_ json: T?, _ error: Error?) -> Void) -> URLSessionDataTaskProtocol?
     func request() -> URLRequest?
+
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    func load<T: Codable>(_ session: RequestKitURLSession, decoder: JSONDecoder, expectedResultType _: T.Type) async throws -> T
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    func load<T: Codable>(_ session: RequestKitURLSession, dateDecodingStrategy: JSONDecoder.DateDecodingStrategy?, expectedResultType: T.Type) async throws -> T
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    func load(_ session: RequestKitURLSession) async throws
+    #endif
 }
 
 public extension Router {

--- a/Sources/RequestKit/Router.swift
+++ b/Sources/RequestKit/Router.swift
@@ -249,6 +249,23 @@ public extension Router {
         }
         return try await load(session, decoder: decoder, expectedResultType: expectedResultType)
     }
+
+    func load(_ session: RequestKitURLSession = URLSession.shared) async throws {
+        guard let request = request() else {
+            throw NSError(domain: configuration.errorDomain, code: -876, userInfo: nil)
+        }
+
+        let responseTuple = try await session.data(for: request, delegate: nil)
+        if let response = responseTuple.1 as? HTTPURLResponse {
+            if response.wasSuccessful == false {
+                var userInfo = [String: Any]()
+                if let json = try? JSONSerialization.jsonObject(with: responseTuple.0, options: .mutableContainers) as? [String: Any] {
+                    userInfo[RequestKitErrorKey] = json as Any?
+                }
+                throw NSError(domain: configuration.errorDomain, code: response.statusCode, userInfo: userInfo)
+            }
+        }
+    }
 }
 #endif
 

--- a/Tests/RequestKitTests/RouterTests.swift
+++ b/Tests/RequestKitTests/RouterTests.swift
@@ -143,6 +143,23 @@ class RouterTests: XCTestCase {
         XCTAssertTrue(session.wasCalled)
         XCTAssertTrue(receivedFailureResponse)
     }
+
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    func testEmptyResponseWithLoadAndIgnoreResponseBodyAsync() async throws {
+        let session = RequestKitURLTestSession(expectedURL: "https://example.com/some_route", expectedHTTPMethod: "POST", response: "", statusCode: 204)
+
+        var receivedSuccessResponse = false
+        do {
+            _ = try await TestInterface().loadAndIgnoreResponseBody(session)
+            receivedSuccessResponse = true
+        } catch {
+            XCTFail("should not catch any error")
+        }
+        XCTAssertTrue(session.wasCalled)
+        XCTAssertTrue(receivedSuccessResponse)
+    }
+    #endif
 }
 
 enum TestRouter: Router {

--- a/Tests/RequestKitTests/TestInterface.swift
+++ b/Tests/RequestKitTests/TestInterface.swift
@@ -67,6 +67,14 @@ class TestInterface {
             }
         }
     }
+
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    func loadAndIgnoreResponseBody(_ session: RequestKitURLSession) async throws {
+        let router = JSONTestRouter.testPOST(configuration)
+        return try await router.load(session)
+    }
+    #endif
 }
 
 enum JSONTestRouter: JSONPostRouter {


### PR DESCRIPTION
Some APIs in GitHub returns empty response body.
ex: https://docs.github.com/en/rest/activity/starring#check-if-a-repository-is-starred-by-the-authenticated-user

In this PR,
1. added a replacement for `load(_ session: RequestKitURLSession = URLSession.shared, completion: @escaping (_ error: Error?) -> Void)` with `async/await` to request that returns empty response body
1. added functions (includes existing) to protocol
1. group functions that using async/await
