### PR TITLE
Add default JSONDecoder to Configuration protocol

### DIFF
--- a/Sources/RequestKit/JSONPostRouter.swift
+++ b/Sources/RequestKit/JSONPostRouter.swift
@@ -93,7 +93,8 @@ public extension JSONPostRouter {
     #endif
 
     func post<T: Decodable>(_ session: RequestKitURLSession = URLSession.shared, expectedResultType: T.Type,
-                            completion: @escaping (_ json: T?, _ error: Error?) -> Void) -> URLSessionDataTaskProtocol? {
+                            completion: @escaping (_ json: T?, _ error: Error?) -> Void) -> URLSessionDataTaskProtocol?
+    {
         return post(session, decoder: configuration.decoder, expectedResultType: expectedResultType, completion: completion)
     }
 

--- a/Sources/RequestKit/JSONPostRouter.swift
+++ b/Sources/RequestKit/JSONPostRouter.swift
@@ -92,6 +92,11 @@ public extension JSONPostRouter {
     }
     #endif
 
+    func post<T: Decodable>(_ session: RequestKitURLSession = URLSession.shared, expectedResultType: T.Type,
+                            completion: @escaping (_ json: T?, _ error: Error?) -> Void) -> URLSessionDataTaskProtocol? {
+        return post(session, decoder: configuration.decoder, expectedResultType: expectedResultType, completion: completion)
+    }
+
     func post<T: Decodable>(_ session: RequestKitURLSession = URLSession.shared, dateDecodingStrategy: JSONDecoder.DateDecodingStrategy?, expectedResultType: T.Type,
                             completion: @escaping (_ json: T?, _ error: Error?) -> Void) -> URLSessionDataTaskProtocol?
     {
@@ -148,6 +153,11 @@ public extension JSONPostRouter {
     }
 
     #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    func post<T: Decodable>(_ session: RequestKitURLSession = URLSession.shared, expectedResultType: T.Type) async throws -> T {
+        return try await post(session, decoder: configuration.decoder, expectedResultType: expectedResultType)
+    }
+
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func post<T: Decodable>(_ session: RequestKitURLSession = URLSession.shared, dateDecodingStrategy: JSONDecoder.DateDecodingStrategy?, expectedResultType: T.Type) async throws -> T {
         let decoder = JSONDecoder()

--- a/Sources/RequestKit/Router.swift
+++ b/Sources/RequestKit/Router.swift
@@ -27,6 +27,7 @@ public protocol Configuration {
     var authorizationHeader: String? { get }
     var errorDomain: String { get }
     var customHeaders: [HTTPHeader]? { get }
+    var decoder: JSONDecoder { get }
 }
 
 public extension Configuration {
@@ -44,6 +45,10 @@ public extension Configuration {
 
     var customHeaders: [HTTPHeader]? {
         return nil
+    }
+
+    var decoder: JSONDecoder {
+        return JSONDecoder()
     }
 }
 
@@ -204,6 +209,11 @@ public extension Router {
         return task
     }
 
+    func load<T: Decodable>(_ session: RequestKitURLSession = URLSession.shared, expectedResultType: T.Type,
+                            completion: @escaping (_ json: T?, _ error: Error?) -> Void) -> URLSessionDataTaskProtocol? {
+        return load(session, decoder: configuration.decoder, expectedResultType: expectedResultType, completion: completion)
+    }
+
     func load(_ session: RequestKitURLSession = URLSession.shared, completion: @escaping (_ error: Error?) -> Void) -> URLSessionDataTaskProtocol? {
         guard let request = request() else {
             return nil
@@ -250,6 +260,10 @@ public extension Router {
         }
 
         return try decoder.decode(T.self, from: responseTuple.0)
+    }
+
+    func load<T: Decodable>(_ session: RequestKitURLSession = URLSession.shared, expectedResultType: T.Type) async throws -> T {
+        return try await load(session, decoder: configuration.decoder, expectedResultType: expectedResultType)
     }
 
     func load<T: Decodable>(_ session: RequestKitURLSession = URLSession.shared, dateDecodingStrategy: JSONDecoder.DateDecodingStrategy?, expectedResultType: T.Type) async throws -> T {

--- a/Sources/RequestKit/Router.swift
+++ b/Sources/RequestKit/Router.swift
@@ -210,7 +210,8 @@ public extension Router {
     }
 
     func load<T: Decodable>(_ session: RequestKitURLSession = URLSession.shared, expectedResultType: T.Type,
-                            completion: @escaping (_ json: T?, _ error: Error?) -> Void) -> URLSessionDataTaskProtocol? {
+                            completion: @escaping (_ json: T?, _ error: Error?) -> Void) -> URLSessionDataTaskProtocol?
+    {
         return load(session, decoder: configuration.decoder, expectedResultType: expectedResultType, completion: completion)
     }
 

--- a/Tests/RequestKitTests/ConfigurationTests.swift
+++ b/Tests/RequestKitTests/ConfigurationTests.swift
@@ -78,7 +78,9 @@ class TestConfigurationWithDecoder: Configuration {
         customDecoder = decoder
     }
 
-    var decoder: JSONDecoder { customDecoder }
+    var decoder: JSONDecoder {
+        customDecoder
+    }
 }
 
 class TestAuthorizationHeaderConfiguration: Configuration {

--- a/Tests/RequestKitTests/ConfigurationTests.swift
+++ b/Tests/RequestKitTests/ConfigurationTests.swift
@@ -27,6 +27,18 @@ class ConfigurationTests: XCTestCase {
         XCTAssertEqual(config.accessTokenFieldName, "access_token")
         XCTAssertEqual(config.authorizationHeader, "BEARER")
     }
+
+    func testDefaultDecoderIsJSONDecoder() {
+        let config = TestConfiguration("1234", url: "https://github.com")
+        XCTAssertNotNil(config.decoder)
+    }
+
+    func testCustomDecoderIsReturned() {
+        let customDecoder = JSONDecoder()
+        customDecoder.keyDecodingStrategy = .convertFromSnakeCase
+        let config = TestConfigurationWithDecoder("1234", url: "https://github.com", decoder: customDecoder)
+        XCTAssertTrue(config.decoder === customDecoder)
+    }
 }
 
 class TestConfiguration: Configuration {
@@ -53,6 +65,20 @@ class TestCustomConfiguration: Configuration {
     var accessTokenFieldName: String {
         return "custom_field"
     }
+}
+
+class TestConfigurationWithDecoder: Configuration {
+    var apiEndpoint: String
+    var accessToken: String?
+    let customDecoder: JSONDecoder
+
+    init(_ token: String, url: String, decoder: JSONDecoder) {
+        apiEndpoint = url
+        accessToken = token
+        customDecoder = decoder
+    }
+
+    var decoder: JSONDecoder { customDecoder }
 }
 
 class TestAuthorizationHeaderConfiguration: Configuration {


### PR DESCRIPTION
Callers (e.g. Octokit.swift) were recreating an identical JSONDecoder on every request. Configuration now exposes a decoder property with a default implementation returning JSONDecoder(), and load()/post() fall back to configuration.decoder when no explicit decoder is passed.