### PR TITLE
Add Link header pagination helpers

### DIFF
--- a/RequestKit.xcodeproj/project.pbxproj
+++ b/RequestKit.xcodeproj/project.pbxproj
@@ -11,6 +11,13 @@
 		233743521C79833A00013492 /* RequestKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 233743001C7981A800013492 /* RequestKit.framework */; };
 		234F4C271BDDF64300A58EF7 /* RequestKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 234F4C1C1BDDF64300A58EF7 /* RequestKit.framework */; };
 		7679BFEF20AB081C0052BBDC /* JSONPostRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7679BFEA20AB081C0052BBDC /* JSONPostRouter.swift */; };
+		11ADDB81114B482286C3139D /* Pagination.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5F1002C9498493CA08C2C7F /* Pagination.swift */; };
+		910C07678A2D49F69AF91915 /* Pagination.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5F1002C9498493CA08C2C7F /* Pagination.swift */; };
+		84D774D0971B414A99A66B3D /* Pagination.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5F1002C9498493CA08C2C7F /* Pagination.swift */; };
+		EDC22C23AAD3434EAD2F120C /* Pagination.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5F1002C9498493CA08C2C7F /* Pagination.swift */; };
+		53DA4143983C4C82B6C6A44F /* PaginationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9041E7A74CB34C39A27694BB /* PaginationTests.swift */; };
+		DEF5E2D67E0D4081A97E5C13 /* PaginationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9041E7A74CB34C39A27694BB /* PaginationTests.swift */; };
+		A3FD2E1BDF7B4D35853CE0EF /* PaginationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9041E7A74CB34C39A27694BB /* PaginationTests.swift */; };
 		7679BFF020AB081C0052BBDC /* JSONPostRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7679BFEA20AB081C0052BBDC /* JSONPostRouter.swift */; };
 		7679BFF120AB081C0052BBDC /* JSONPostRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7679BFEA20AB081C0052BBDC /* JSONPostRouter.swift */; };
 		7679BFF220AB081C0052BBDC /* JSONPostRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7679BFEA20AB081C0052BBDC /* JSONPostRouter.swift */; };
@@ -82,12 +89,14 @@
 		7679BFEB20AB081C0052BBDC /* RequestKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RequestKit.h; sourceTree = "<group>"; };
 		7679BFEC20AB081C0052BBDC /* RequestKitSession.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestKitSession.swift; sourceTree = "<group>"; };
 		7679BFED20AB081C0052BBDC /* Router.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Router.swift; sourceTree = "<group>"; };
+		E5F1002C9498493CA08C2C7F /* Pagination.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Pagination.swift; sourceTree = "<group>"; };
 		7679BFEE20AB081C0052BBDC /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		7679C00620AB08290052BBDC /* RequestKitURLTestSession.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestKitURLTestSession.swift; sourceTree = "<group>"; };
 		7679C00720AB08290052BBDC /* RouterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RouterTests.swift; sourceTree = "<group>"; };
 		7679C00920AB08290052BBDC /* ConfigurationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConfigurationTests.swift; sourceTree = "<group>"; };
 		7679C00A20AB08290052BBDC /* TestHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestHelper.swift; sourceTree = "<group>"; };
 		7679C00B20AB08290052BBDC /* JSONPostRouterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONPostRouterTests.swift; sourceTree = "<group>"; };
+		9041E7A74CB34C39A27694BB /* PaginationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaginationTests.swift; sourceTree = "<group>"; };
 		7679C00C20AB08290052BBDC /* TestInterface.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestInterface.swift; sourceTree = "<group>"; };
 		7679C00D20AB08290052BBDC /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -186,6 +195,7 @@
 				7679BFED20AB081C0052BBDC /* Router.swift */,
 				7679BFEA20AB081C0052BBDC /* JSONPostRouter.swift */,
 				7679BFEC20AB081C0052BBDC /* RequestKitSession.swift */,
+				E5F1002C9498493CA08C2C7F /* Pagination.swift */,
 				7679BFEE20AB081C0052BBDC /* Info.plist */,
 			);
 			path = RequestKit;
@@ -207,6 +217,7 @@
 				7679C00720AB08290052BBDC /* RouterTests.swift */,
 				7679C00920AB08290052BBDC /* ConfigurationTests.swift */,
 				7679C00B20AB08290052BBDC /* JSONPostRouterTests.swift */,
+				9041E7A74CB34C39A27694BB /* PaginationTests.swift */,
 				7679C00A20AB08290052BBDC /* TestHelper.swift */,
 				7679C00D20AB08290052BBDC /* Info.plist */,
 			);
@@ -449,6 +460,7 @@
 				7679BFF820AB081C0052BBDC /* RequestKitSession.swift in Sources */,
 				7679BFF020AB081C0052BBDC /* JSONPostRouter.swift in Sources */,
 				7679BFFC20AB081C0052BBDC /* Router.swift in Sources */,
+				11ADDB81114B482286C3139D /* Pagination.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -459,6 +471,7 @@
 				7679BFF920AB081C0052BBDC /* RequestKitSession.swift in Sources */,
 				7679BFF120AB081C0052BBDC /* JSONPostRouter.swift in Sources */,
 				7679BFFD20AB081C0052BBDC /* Router.swift in Sources */,
+				910C07678A2D49F69AF91915 /* Pagination.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -469,6 +482,7 @@
 				7679BFFA20AB081C0052BBDC /* RequestKitSession.swift in Sources */,
 				7679BFF220AB081C0052BBDC /* JSONPostRouter.swift in Sources */,
 				7679BFFE20AB081C0052BBDC /* Router.swift in Sources */,
+				84D774D0971B414A99A66B3D /* Pagination.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -482,6 +496,7 @@
 				7679C01F20AB08290052BBDC /* TestHelper.swift in Sources */,
 				7679C02220AB08290052BBDC /* JSONPostRouterTests.swift in Sources */,
 				7679C01620AB08290052BBDC /* RouterTests.swift in Sources */,
+				53DA4143983C4C82B6C6A44F /* PaginationTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -495,6 +510,7 @@
 				7679C01E20AB08290052BBDC /* TestHelper.swift in Sources */,
 				7679C02120AB08290052BBDC /* JSONPostRouterTests.swift in Sources */,
 				7679C01520AB08290052BBDC /* RouterTests.swift in Sources */,
+				DEF5E2D67E0D4081A97E5C13 /* PaginationTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -505,6 +521,7 @@
 				7679BFF720AB081C0052BBDC /* RequestKitSession.swift in Sources */,
 				7679BFEF20AB081C0052BBDC /* JSONPostRouter.swift in Sources */,
 				7679BFFB20AB081C0052BBDC /* Router.swift in Sources */,
+				EDC22C23AAD3434EAD2F120C /* Pagination.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -518,6 +535,7 @@
 				7679C01D20AB08290052BBDC /* TestHelper.swift in Sources */,
 				7679C02020AB08290052BBDC /* JSONPostRouterTests.swift in Sources */,
 				7679C01420AB08290052BBDC /* RouterTests.swift in Sources */,
+				A3FD2E1BDF7B4D35853CE0EF /* PaginationTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/RequestKit/Pagination.swift
+++ b/Sources/RequestKit/Pagination.swift
@@ -1,0 +1,49 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// Pagination links parsed from an RFC 5988 `Link` response header.
+public struct PageInfo {
+    public let next: URL?
+    public let prev: URL?
+    public let first: URL?
+    public let last: URL?
+
+    public var hasNextPage: Bool { next != nil }
+
+    /// Parse a Link header value, e.g.:
+    /// `<https://api.github.com/repos?page=2>; rel="next", <https://api.github.com/repos?page=5>; rel="last"`
+    public init(linkHeader: String?) {
+        guard let header = linkHeader else {
+            next = nil; prev = nil; first = nil; last = nil
+            return
+        }
+        var links: [String: URL] = [:]
+        let entries = header.components(separatedBy: ", ")
+        for entry in entries {
+            let parts = entry.components(separatedBy: "; ")
+            guard parts.count == 2 else { continue }
+            let urlPart = parts[0].trimmingCharacters(in: .whitespaces)
+            let relPart = parts[1].trimmingCharacters(in: .whitespaces)
+            guard urlPart.hasPrefix("<"), urlPart.hasSuffix(">") else { continue }
+            let urlString = String(urlPart.dropFirst().dropLast())
+            guard let url = URL(string: urlString) else { continue }
+            let relValue = relPart
+                .replacingOccurrences(of: "rel=", with: "")
+                .replacingOccurrences(of: "\"", with: "")
+                .trimmingCharacters(in: .whitespaces)
+            links[relValue] = url
+        }
+        next = links["next"]
+        prev = links["prev"]
+        first = links["first"]
+        last = links["last"]
+    }
+}
+
+/// A decoded response along with its pagination metadata.
+public struct PaginatedResponse<T> {
+    public let values: T
+    public let pageInfo: PageInfo
+}

--- a/Sources/RequestKit/Pagination.swift
+++ b/Sources/RequestKit/Pagination.swift
@@ -10,7 +10,9 @@ public struct PageInfo {
     public let first: URL?
     public let last: URL?
 
-    public var hasNextPage: Bool { next != nil }
+    public var hasNextPage: Bool {
+        next != nil
+    }
 
     /// Parse a Link header value, e.g.:
     /// `<https://api.github.com/repos?page=2>; rel="next", <https://api.github.com/repos?page=5>; rel="last"`

--- a/Sources/RequestKit/Router.swift
+++ b/Sources/RequestKit/Router.swift
@@ -322,6 +322,36 @@ public extension Router {
         task.resume()
         return task
     }
+
+    @discardableResult
+    func loadPaginated<T: Codable>(_ session: RequestKitURLSession = URLSession.shared,
+                                   decoder: JSONDecoder = JSONDecoder(),
+                                   expectedResultType _: T.Type,
+                                   completion: @escaping (_ response: PaginatedResponse<T>?, _ error: Error?) -> Void) -> URLSessionDataTaskProtocol? {
+        guard let request = request() else { return nil }
+        let task = session.dataTask(with: request) { data, response, err in
+            if let response = response as? HTTPURLResponse, !response.wasSuccessful {
+                var userInfo = [String: Any]()
+                if let data = data, let json = try? JSONSerialization.jsonObject(with: data, options: .mutableContainers) as? [String: Any] {
+                    userInfo[RequestKitErrorKey] = json as Any?
+                }
+                completion(nil, NSError(domain: self.configuration.errorDomain, code: response.statusCode, userInfo: userInfo))
+                return
+            }
+            if let err = err { completion(nil, err); return }
+            guard let data = data else { return }
+            do {
+                let decoded = try decoder.decode(T.self, from: data)
+                let linkHeader = (response as? HTTPURLResponse)?.allHeaderFields["Link"] as? String
+                let pageInfo = PageInfo(linkHeader: linkHeader)
+                completion(PaginatedResponse(values: decoded, pageInfo: pageInfo), nil)
+            } catch {
+                completion(nil, error)
+            }
+        }
+        task.resume()
+        return task
+    }
 }
 
 #if compiler(>=5.5.2) && canImport(_Concurrency)
@@ -424,6 +454,25 @@ public extension Router {
             throw NSError(domain: configuration.errorDomain, code: response.statusCode, userInfo: userInfo)
         }
         return try decoder.decode(T.self, from: responseData)
+    }
+
+    func loadPaginated<T: Codable>(_ session: RequestKitURLSession = URLSession.shared,
+                                   decoder: JSONDecoder = JSONDecoder(),
+                                   expectedResultType _: T.Type) async throws -> PaginatedResponse<T> {
+        guard let request = request() else {
+            throw NSError(domain: configuration.errorDomain, code: -876, userInfo: nil)
+        }
+        let (data, response) = try await session.data(for: request, delegate: nil)
+        if let httpResponse = response as? HTTPURLResponse, !httpResponse.wasSuccessful {
+            var userInfo = [String: Any]()
+            if let json = try? JSONSerialization.jsonObject(with: data, options: .mutableContainers) as? [String: Any] {
+                userInfo[RequestKitErrorKey] = json as Any?
+            }
+            throw NSError(domain: configuration.errorDomain, code: httpResponse.statusCode, userInfo: userInfo)
+        }
+        let decoded = try decoder.decode(T.self, from: data)
+        let linkHeader = (response as? HTTPURLResponse)?.allHeaderFields["Link"] as? String
+        return PaginatedResponse(values: decoded, pageInfo: PageInfo(linkHeader: linkHeader))
     }
 }
 #endif

--- a/Sources/RequestKit/Router.swift
+++ b/Sources/RequestKit/Router.swift
@@ -327,7 +327,8 @@ public extension Router {
     func loadPaginated<T: Codable>(_ session: RequestKitURLSession = URLSession.shared,
                                    decoder: JSONDecoder = JSONDecoder(),
                                    expectedResultType _: T.Type,
-                                   completion: @escaping (_ response: PaginatedResponse<T>?, _ error: Error?) -> Void) -> URLSessionDataTaskProtocol? {
+                                   completion: @escaping (_ response: PaginatedResponse<T>?, _ error: Error?) -> Void) -> URLSessionDataTaskProtocol?
+    {
         guard let request = request() else { return nil }
         let task = session.dataTask(with: request) { data, response, err in
             if let response = response as? HTTPURLResponse, !response.wasSuccessful {
@@ -458,7 +459,8 @@ public extension Router {
 
     func loadPaginated<T: Codable>(_ session: RequestKitURLSession = URLSession.shared,
                                    decoder: JSONDecoder = JSONDecoder(),
-                                   expectedResultType _: T.Type) async throws -> PaginatedResponse<T> {
+                                   expectedResultType _: T.Type) async throws -> PaginatedResponse<T>
+    {
         guard let request = request() else {
             throw NSError(domain: configuration.errorDomain, code: -876, userInfo: nil)
         }

--- a/Tests/RequestKitTests/PaginationTests.swift
+++ b/Tests/RequestKitTests/PaginationTests.swift
@@ -1,0 +1,141 @@
+import Foundation
+import RequestKit
+import XCTest
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+class PaginationTests: XCTestCase {
+
+    func testPageInfoParsingWithAllRels() {
+        let header = "<https://api.github.com/repos?page=2>; rel=\"next\", <https://api.github.com/repos?page=5>; rel=\"last\", <https://api.github.com/repos?page=1>; rel=\"first\", <https://api.github.com/repos?page=1>; rel=\"prev\""
+        let pageInfo = PageInfo(linkHeader: header)
+        XCTAssertEqual(pageInfo.next?.absoluteString, "https://api.github.com/repos?page=2")
+        XCTAssertEqual(pageInfo.last?.absoluteString, "https://api.github.com/repos?page=5")
+        XCTAssertEqual(pageInfo.first?.absoluteString, "https://api.github.com/repos?page=1")
+        XCTAssertEqual(pageInfo.prev?.absoluteString, "https://api.github.com/repos?page=1")
+        XCTAssertTrue(pageInfo.hasNextPage)
+    }
+
+    func testPageInfoParsingWithOnlyNext() {
+        let header = "<https://api.github.com/repos?page=2>; rel=\"next\""
+        let pageInfo = PageInfo(linkHeader: header)
+        XCTAssertNotNil(pageInfo.next)
+        XCTAssertNil(pageInfo.prev)
+        XCTAssertNil(pageInfo.last)
+        XCTAssertTrue(pageInfo.hasNextPage)
+    }
+
+    func testPageInfoParsingWithNilHeader() {
+        let pageInfo = PageInfo(linkHeader: nil)
+        XCTAssertNil(pageInfo.next)
+        XCTAssertNil(pageInfo.prev)
+        XCTAssertNil(pageInfo.first)
+        XCTAssertNil(pageInfo.last)
+        XCTAssertFalse(pageInfo.hasNextPage)
+    }
+
+    func testPageInfoParsingLastPage() {
+        let header = "<https://api.github.com/repos?page=1>; rel=\"first\", <https://api.github.com/repos?page=4>; rel=\"prev\""
+        let pageInfo = PageInfo(linkHeader: header)
+        XCTAssertNil(pageInfo.next)
+        XCTAssertFalse(pageInfo.hasNextPage)
+    }
+
+    func testLoadPaginatedReturnsPageInfo() {
+        let json = "[\"a\", \"b\"]"
+        let linkHeader = "<https://api.github.com/repos?page=2>; rel=\"next\", <https://api.github.com/repos?page=5>; rel=\"last\""
+        let session = PaginatedTestSession(
+            expectedURL: "https://example.com/some_route",
+            expectedHTTPMethod: "GET",
+            response: json,
+            statusCode: 200,
+            linkHeader: linkHeader
+        )
+        let config = TestInterfaceConfiguration(url: "https://example.com")
+        let router = JSONTestRouter.testGET(config)
+
+        let expectation = XCTestExpectation(description: "load paginated")
+        router.loadPaginated(session, expectedResultType: [String].self) { response, error in
+            XCTAssertNil(error)
+            XCTAssertEqual(response?.values, ["a", "b"])
+            XCTAssertEqual(response?.pageInfo.next?.absoluteString, "https://api.github.com/repos?page=2")
+            XCTAssertTrue(response?.pageInfo.hasNextPage ?? false)
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    func testLoadPaginatedAsyncReturnsPageInfo() async throws {
+        let json = "[\"a\", \"b\"]"
+        let linkHeader = "<https://api.github.com/repos?page=2>; rel=\"next\", <https://api.github.com/repos?page=5>; rel=\"last\""
+        let session = PaginatedTestSession(
+            expectedURL: "https://example.com/some_route",
+            expectedHTTPMethod: "GET",
+            response: json,
+            statusCode: 200,
+            linkHeader: linkHeader
+        )
+        let config = TestInterfaceConfiguration(url: "https://example.com")
+        let router = JSONTestRouter.testGET(config)
+        let response = try await router.loadPaginated(session, expectedResultType: [String].self)
+        XCTAssertEqual(response.values, ["a", "b"])
+        XCTAssertEqual(response.pageInfo.next?.absoluteString, "https://api.github.com/repos?page=2")
+        XCTAssertTrue(response.pageInfo.hasNextPage)
+    }
+    #endif
+}
+
+class PaginatedTestSession: RequestKitURLSession {
+    var wasCalled = false
+    let expectedURL: String
+    let expectedHTTPMethod: String
+    let responseString: String?
+    let statusCode: Int
+    let linkHeader: String?
+
+    init(expectedURL: String, expectedHTTPMethod: String, response: String?, statusCode: Int, linkHeader: String?) {
+        self.expectedURL = expectedURL
+        self.expectedHTTPMethod = expectedHTTPMethod
+        responseString = response
+        self.statusCode = statusCode
+        self.linkHeader = linkHeader
+    }
+
+    func dataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTaskProtocol {
+        XCTAssertEqual(request.url?.absoluteString, expectedURL)
+        XCTAssertEqual(request.httpMethod, expectedHTTPMethod)
+        let data = responseString?.data(using: .utf8)
+        var headers: [String: String] = ["Content-Type": "application/json"]
+        if let link = linkHeader { headers["Link"] = link }
+        let response = HTTPURLResponse(url: request.url!, statusCode: statusCode, httpVersion: "http/1.1", headerFields: headers)
+        completionHandler(data, response, nil)
+        wasCalled = true
+        return MockURLSessionDataTask()
+    }
+
+    func uploadTask(with request: URLRequest, fromData _: Data?, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTaskProtocol {
+        fatalError("uploadTask not expected in PaginatedTestSession")
+    }
+
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    func data(for request: URLRequest, delegate _: URLSessionTaskDelegate?) async throws -> (Data, URLResponse) {
+        XCTAssertEqual(request.url?.absoluteString, expectedURL)
+        XCTAssertEqual(request.httpMethod, expectedHTTPMethod)
+        let data = responseString?.data(using: .utf8) ?? Data()
+        var headers: [String: String] = ["Content-Type": "application/json"]
+        if let link = linkHeader { headers["Link"] = link }
+        let response = HTTPURLResponse(url: request.url!, statusCode: statusCode, httpVersion: "http/1.1", headerFields: headers)!
+        wasCalled = true
+        return (data, response)
+    }
+
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    func upload(for request: URLRequest, from _: Data, delegate _: URLSessionTaskDelegate?) async throws -> (Data, URLResponse) {
+        fatalError("upload not expected in PaginatedTestSession")
+    }
+    #endif
+}

--- a/Tests/RequestKitTests/PaginationTests.swift
+++ b/Tests/RequestKitTests/PaginationTests.swift
@@ -6,7 +6,6 @@ import FoundationNetworking
 #endif
 
 class PaginationTests: XCTestCase {
-
     func testPageInfoParsingWithAllRels() {
         let header = "<https://api.github.com/repos?page=2>; rel=\"next\", <https://api.github.com/repos?page=5>; rel=\"last\", <https://api.github.com/repos?page=1>; rel=\"first\", <https://api.github.com/repos?page=1>; rel=\"prev\""
         let pageInfo = PageInfo(linkHeader: header)
@@ -108,7 +107,7 @@ class PaginatedTestSession: RequestKitURLSession {
         XCTAssertEqual(request.url?.absoluteString, expectedURL)
         XCTAssertEqual(request.httpMethod, expectedHTTPMethod)
         let data = responseString?.data(using: .utf8)
-        var headers: [String: String] = ["Content-Type": "application/json"]
+        var headers = ["Content-Type": "application/json"]
         if let link = linkHeader { headers["Link"] = link }
         let response = HTTPURLResponse(url: request.url!, statusCode: statusCode, httpVersion: "http/1.1", headerFields: headers)
         completionHandler(data, response, nil)
@@ -116,7 +115,7 @@ class PaginatedTestSession: RequestKitURLSession {
         return MockURLSessionDataTask()
     }
 
-    func uploadTask(with request: URLRequest, fromData _: Data?, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTaskProtocol {
+    func uploadTask(with _: URLRequest, fromData _: Data?, completionHandler _: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTaskProtocol {
         fatalError("uploadTask not expected in PaginatedTestSession")
     }
 
@@ -126,7 +125,7 @@ class PaginatedTestSession: RequestKitURLSession {
         XCTAssertEqual(request.url?.absoluteString, expectedURL)
         XCTAssertEqual(request.httpMethod, expectedHTTPMethod)
         let data = responseString?.data(using: .utf8) ?? Data()
-        var headers: [String: String] = ["Content-Type": "application/json"]
+        var headers = ["Content-Type": "application/json"]
         if let link = linkHeader { headers["Link"] = link }
         let response = HTTPURLResponse(url: request.url!, statusCode: statusCode, httpVersion: "http/1.1", headerFields: headers)!
         wasCalled = true
@@ -134,7 +133,7 @@ class PaginatedTestSession: RequestKitURLSession {
     }
 
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-    func upload(for request: URLRequest, from _: Data, delegate _: URLSessionTaskDelegate?) async throws -> (Data, URLResponse) {
+    func upload(for _: URLRequest, from _: Data, delegate _: URLSessionTaskDelegate?) async throws -> (Data, URLResponse) {
         fatalError("upload not expected in PaginatedTestSession")
     }
     #endif


### PR DESCRIPTION
Adds PageInfo (parses RFC 5988 Link headers into next/prev/first/last URLs) and PaginatedResponse<T> structs, plus loadPaginated() on Router with callback and async/await variants. Enables callers to detect and navigate multi-page API responses without manual Link header parsing.