### PR TITLE
Add DELETE/PUT/PATCH convenience methods to Router

### DIFF
--- a/Sources/RequestKit/Router.swift
+++ b/Sources/RequestKit/Router.swift
@@ -227,6 +227,88 @@ public extension Router {
         task.resume()
         return task
     }
+
+    @discardableResult
+    func delete(_ session: RequestKitURLSession = URLSession.shared, completion: @escaping (_ error: Error?) -> Void) -> URLSessionDataTaskProtocol? {
+        guard let request = request() else { return nil }
+        let task = session.dataTask(with: request) { data, response, err in
+            if let response = response as? HTTPURLResponse, !response.wasSuccessful {
+                var userInfo = [String: Any]()
+                if let data = data, let json = try? JSONSerialization.jsonObject(with: data, options: .mutableContainers) as? [String: Any] {
+                    userInfo[RequestKitErrorKey] = json as Any?
+                }
+                completion(NSError(domain: self.configuration.errorDomain, code: response.statusCode, userInfo: userInfo))
+                return
+            }
+            completion(err)
+        }
+        task.resume()
+        return task
+    }
+
+    @discardableResult
+    func put<T: Codable>(_ session: RequestKitURLSession = URLSession.shared, decoder: JSONDecoder = JSONDecoder(), expectedResultType _: T.Type,
+                         completion: @escaping (_ json: T?, _ error: Error?) -> Void) -> URLSessionDataTaskProtocol? {
+        guard let request = request() else { return nil }
+        let data: Data
+        do {
+            data = try JSONSerialization.data(withJSONObject: params, options: JSONSerialization.WritingOptions())
+        } catch {
+            completion(nil, error)
+            return nil
+        }
+        let task = session.uploadTask(with: request, fromData: data) { data, response, error in
+            if let response = response as? HTTPURLResponse, !response.wasSuccessful {
+                var userInfo = [String: Any]()
+                if let data = data, let json = try? JSONSerialization.jsonObject(with: data, options: .mutableContainers) as? [String: Any] {
+                    userInfo[RequestKitErrorKey] = json as Any?
+                } else if let data = data, let string = String(data: data, encoding: .utf8) {
+                    userInfo[RequestKitErrorKey] = string as Any?
+                }
+                completion(nil, NSError(domain: self.configuration.errorDomain, code: response.statusCode, userInfo: userInfo))
+                return
+            }
+            if let error = error { completion(nil, error); return }
+            if let data = data {
+                do { completion(try decoder.decode(T.self, from: data), nil) }
+                catch { completion(nil, error) }
+            }
+        }
+        task.resume()
+        return task
+    }
+
+    @discardableResult
+    func patch<T: Codable>(_ session: RequestKitURLSession = URLSession.shared, decoder: JSONDecoder = JSONDecoder(), expectedResultType _: T.Type,
+                           completion: @escaping (_ json: T?, _ error: Error?) -> Void) -> URLSessionDataTaskProtocol? {
+        guard let request = request() else { return nil }
+        let data: Data
+        do {
+            data = try JSONSerialization.data(withJSONObject: params, options: JSONSerialization.WritingOptions())
+        } catch {
+            completion(nil, error)
+            return nil
+        }
+        let task = session.uploadTask(with: request, fromData: data) { data, response, error in
+            if let response = response as? HTTPURLResponse, !response.wasSuccessful {
+                var userInfo = [String: Any]()
+                if let data = data, let json = try? JSONSerialization.jsonObject(with: data, options: .mutableContainers) as? [String: Any] {
+                    userInfo[RequestKitErrorKey] = json as Any?
+                } else if let data = data, let string = String(data: data, encoding: .utf8) {
+                    userInfo[RequestKitErrorKey] = string as Any?
+                }
+                completion(nil, NSError(domain: self.configuration.errorDomain, code: response.statusCode, userInfo: userInfo))
+                return
+            }
+            if let error = error { completion(nil, error); return }
+            if let data = data {
+                do { completion(try decoder.decode(T.self, from: data), nil) }
+                catch { completion(nil, error) }
+            }
+        }
+        task.resume()
+        return task
+    }
 }
 
 #if compiler(>=5.5.2) && canImport(_Concurrency)
@@ -275,6 +357,56 @@ public extension Router {
                 throw NSError(domain: configuration.errorDomain, code: response.statusCode, userInfo: userInfo)
             }
         }
+    }
+
+    func delete(_ session: RequestKitURLSession = URLSession.shared) async throws {
+        guard let request = request() else {
+            throw NSError(domain: configuration.errorDomain, code: -876, userInfo: nil)
+        }
+        let (data, response) = try await session.data(for: request, delegate: nil)
+        if let response = response as? HTTPURLResponse, !response.wasSuccessful {
+            var userInfo = [String: Any]()
+            if let json = try? JSONSerialization.jsonObject(with: data, options: .mutableContainers) as? [String: Any] {
+                userInfo[RequestKitErrorKey] = json as Any?
+            }
+            throw NSError(domain: configuration.errorDomain, code: response.statusCode, userInfo: userInfo)
+        }
+    }
+
+    func put<T: Codable>(_ session: RequestKitURLSession = URLSession.shared, decoder: JSONDecoder = JSONDecoder(), expectedResultType _: T.Type) async throws -> T {
+        guard let request = request() else {
+            throw NSError(domain: configuration.errorDomain, code: -876, userInfo: nil)
+        }
+        let body = try JSONSerialization.data(withJSONObject: params, options: JSONSerialization.WritingOptions())
+        let (responseData, response) = try await session.upload(for: request, from: body, delegate: nil)
+        if let response = response as? HTTPURLResponse, !response.wasSuccessful {
+            var userInfo = [String: Any]()
+            if let json = try? JSONSerialization.jsonObject(with: responseData, options: .mutableContainers) as? [String: Any] {
+                userInfo[RequestKitErrorKey] = json as Any?
+            } else if let string = String(data: responseData, encoding: .utf8) {
+                userInfo[RequestKitErrorKey] = string as Any?
+            }
+            throw NSError(domain: configuration.errorDomain, code: response.statusCode, userInfo: userInfo)
+        }
+        return try decoder.decode(T.self, from: responseData)
+    }
+
+    func patch<T: Codable>(_ session: RequestKitURLSession = URLSession.shared, decoder: JSONDecoder = JSONDecoder(), expectedResultType _: T.Type) async throws -> T {
+        guard let request = request() else {
+            throw NSError(domain: configuration.errorDomain, code: -876, userInfo: nil)
+        }
+        let body = try JSONSerialization.data(withJSONObject: params, options: JSONSerialization.WritingOptions())
+        let (responseData, response) = try await session.upload(for: request, from: body, delegate: nil)
+        if let response = response as? HTTPURLResponse, !response.wasSuccessful {
+            var userInfo = [String: Any]()
+            if let json = try? JSONSerialization.jsonObject(with: responseData, options: .mutableContainers) as? [String: Any] {
+                userInfo[RequestKitErrorKey] = json as Any?
+            } else if let string = String(data: responseData, encoding: .utf8) {
+                userInfo[RequestKitErrorKey] = string as Any?
+            }
+            throw NSError(domain: configuration.errorDomain, code: response.statusCode, userInfo: userInfo)
+        }
+        return try decoder.decode(T.self, from: responseData)
     }
 }
 #endif

--- a/Sources/RequestKit/Router.swift
+++ b/Sources/RequestKit/Router.swift
@@ -248,7 +248,8 @@ public extension Router {
 
     @discardableResult
     func put<T: Codable>(_ session: RequestKitURLSession = URLSession.shared, decoder: JSONDecoder = JSONDecoder(), expectedResultType _: T.Type,
-                         completion: @escaping (_ json: T?, _ error: Error?) -> Void) -> URLSessionDataTaskProtocol? {
+                         completion: @escaping (_ json: T?, _ error: Error?) -> Void) -> URLSessionDataTaskProtocol?
+    {
         guard let request = request() else { return nil }
         let data: Data
         do {
@@ -270,7 +271,7 @@ public extension Router {
             }
             if let error = error { completion(nil, error); return }
             if let data = data {
-                do { completion(try decoder.decode(T.self, from: data), nil) }
+                do { try completion(decoder.decode(T.self, from: data), nil) }
                 catch { completion(nil, error) }
             }
         }
@@ -280,7 +281,8 @@ public extension Router {
 
     @discardableResult
     func patch<T: Codable>(_ session: RequestKitURLSession = URLSession.shared, decoder: JSONDecoder = JSONDecoder(), expectedResultType _: T.Type,
-                           completion: @escaping (_ json: T?, _ error: Error?) -> Void) -> URLSessionDataTaskProtocol? {
+                           completion: @escaping (_ json: T?, _ error: Error?) -> Void) -> URLSessionDataTaskProtocol?
+    {
         guard let request = request() else { return nil }
         let data: Data
         do {
@@ -302,7 +304,7 @@ public extension Router {
             }
             if let error = error { completion(nil, error); return }
             if let data = data {
-                do { completion(try decoder.decode(T.self, from: data), nil) }
+                do { try completion(decoder.decode(T.self, from: data), nil) }
                 catch { completion(nil, error) }
             }
         }

--- a/Tests/RequestKitTests/RouterTests.swift
+++ b/Tests/RequestKitTests/RouterTests.swift
@@ -159,16 +159,111 @@ class RouterTests: XCTestCase {
         XCTAssertTrue(receivedSuccessResponse)
     }
     #endif
+
+    func testDeleteRequest() {
+        let session = RequestKitURLTestSession(expectedURL: "https://example.com/api/v1/some_route?access_token=1234&key1=value1%3A456&key2=value2", expectedHTTPMethod: "DELETE", response: "", statusCode: 204)
+        let config = TestConfiguration("1234", url: "https://example.com/api/v1/")
+        let router = TestRouter.deleteRoute(config)
+        var receivedError: Error?
+        let task = router.delete(session) { error in
+            receivedError = error
+        }
+        XCTAssertNotNil(task)
+        XCTAssertTrue(session.wasCalled)
+        XCTAssertNil(receivedError)
+    }
+
+    func testDeleteRequestError() {
+        let jsonDict = ["message": "Not Found"]
+        let jsonString = String(data: try! JSONSerialization.data(withJSONObject: jsonDict, options: JSONSerialization.WritingOptions()), encoding: .utf8)
+        let session = RequestKitURLTestSession(expectedURL: "https://example.com/api/v1/some_route?access_token=1234&key1=value1%3A456&key2=value2", expectedHTTPMethod: "DELETE", response: jsonString, statusCode: 404)
+        let config = TestConfiguration("1234", url: "https://example.com/api/v1/")
+        let router = TestRouter.deleteRoute(config)
+        var receivedError: Error?
+        let task = router.delete(session) { error in
+            receivedError = error
+        }
+        XCTAssertNotNil(task)
+        XCTAssertTrue(session.wasCalled)
+        XCTAssertEqual(Helper.getNSError(from: receivedError)?.code, 404)
+    }
+
+    func testPutRequest() {
+        let jsonResponse = "{\"key\": \"value\"}"
+        let session = RequestKitURLTestSession(expectedURL: "https://example.com/api/v1/some_route?access_token=1234", expectedHTTPMethod: "PUT", response: jsonResponse, statusCode: 200)
+        let config = TestConfiguration("1234", url: "https://example.com/api/v1/")
+        let router = TestRouter.putRoute(config)
+        var result: [String: String]?
+        let task = router.put(session, expectedResultType: [String: String].self) { json, _ in
+            result = json
+        }
+        XCTAssertNotNil(task)
+        XCTAssertTrue(session.wasCalled)
+        XCTAssertEqual(result?["key"], "value")
+    }
+
+    func testPatchRequest() {
+        let jsonResponse = "{\"key\": \"patched\"}"
+        let session = RequestKitURLTestSession(expectedURL: "https://example.com/api/v1/some_route?access_token=1234", expectedHTTPMethod: "PATCH", response: jsonResponse, statusCode: 200)
+        let config = TestConfiguration("1234", url: "https://example.com/api/v1/")
+        let router = TestRouter.patchRoute(config)
+        var result: [String: String]?
+        let task = router.patch(session, expectedResultType: [String: String].self) { json, _ in
+            result = json
+        }
+        XCTAssertNotNil(task)
+        XCTAssertTrue(session.wasCalled)
+        XCTAssertEqual(result?["key"], "patched")
+    }
+
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    func testDeleteRequestAsync() async throws {
+        let session = RequestKitURLTestSession(expectedURL: "https://example.com/api/v1/some_route?access_token=1234&key1=value1%3A456&key2=value2", expectedHTTPMethod: "DELETE", response: "", statusCode: 204)
+        let config = TestConfiguration("1234", url: "https://example.com/api/v1/")
+        let router = TestRouter.deleteRoute(config)
+        try await router.delete(session)
+        XCTAssertTrue(session.wasCalled)
+    }
+
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    func testPutRequestAsync() async throws {
+        let jsonResponse = "{\"key\": \"value\"}"
+        let session = RequestKitURLTestSession(expectedURL: "https://example.com/api/v1/some_route?access_token=1234", expectedHTTPMethod: "PUT", response: jsonResponse, statusCode: 200)
+        let config = TestConfiguration("1234", url: "https://example.com/api/v1/")
+        let router = TestRouter.putRoute(config)
+        let result: [String: String] = try await router.put(session, expectedResultType: [String: String].self)
+        XCTAssertTrue(session.wasCalled)
+        XCTAssertEqual(result["key"], "value")
+    }
+
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    func testPatchRequestAsync() async throws {
+        let jsonResponse = "{\"key\": \"patched\"}"
+        let session = RequestKitURLTestSession(expectedURL: "https://example.com/api/v1/some_route?access_token=1234", expectedHTTPMethod: "PATCH", response: jsonResponse, statusCode: 200)
+        let config = TestConfiguration("1234", url: "https://example.com/api/v1/")
+        let router = TestRouter.patchRoute(config)
+        let result: [String: String] = try await router.patch(session, expectedResultType: [String: String].self)
+        XCTAssertTrue(session.wasCalled)
+        XCTAssertEqual(result["key"], "patched")
+    }
+    #endif
 }
 
 enum TestRouter: Router {
     case testRoute(Configuration)
     case formEncodedRoute(Configuration)
+    case deleteRoute(Configuration)
+    case putRoute(Configuration)
+    case patchRoute(Configuration)
 
     var configuration: Configuration {
         switch self {
         case let .testRoute(config): return config
         case let .formEncodedRoute(config): return config
+        case let .deleteRoute(config): return config
+        case let .putRoute(config): return config
+        case let .patchRoute(config): return config
         }
     }
 
@@ -178,6 +273,12 @@ enum TestRouter: Router {
             return .GET
         case .formEncodedRoute:
             return .POST
+        case .deleteRoute:
+            return .DELETE
+        case .putRoute:
+            return .PUT
+        case .patchRoute:
+            return .PATCH
         }
     }
 
@@ -187,19 +288,30 @@ enum TestRouter: Router {
             return .url
         case .formEncodedRoute:
             return .form
+        case .deleteRoute:
+            return .url
+        case .putRoute, .patchRoute:
+            return .json
         }
     }
 
     var path: String {
         switch self {
-        case .testRoute:
-            return "some_route"
         case .formEncodedRoute:
             return "route"
+        default:
+            return "some_route"
         }
     }
 
     var params: [String: Any] {
-        return ["key1": "value1:456", "key2": "value2"]
+        switch self {
+        case .deleteRoute:
+            return ["key1": "value1:456", "key2": "value2"]
+        case .putRoute, .patchRoute:
+            return ["key": "value"]
+        default:
+            return ["key1": "value1:456", "key2": "value2"]
+        }
     }
 }

--- a/Tests/RequestKitTests/RouterTests.swift
+++ b/Tests/RequestKitTests/RouterTests.swift
@@ -161,7 +161,12 @@ class RouterTests: XCTestCase {
     #endif
 
     func testDeleteRequest() {
-        let session = RequestKitURLTestSession(expectedURL: "https://example.com/api/v1/some_route?access_token=1234&key1=value1%3A456&key2=value2", expectedHTTPMethod: "DELETE", response: "", statusCode: 204)
+        let session = RequestKitURLTestSession(
+            expectedURL: "https://example.com/api/v1/some_route?access_token=1234&key1=value1%3A456&key2=value2",
+            expectedHTTPMethod: "DELETE",
+            response: "",
+            statusCode: 204
+        )
         let config = TestConfiguration("1234", url: "https://example.com/api/v1/")
         let router = TestRouter.deleteRoute(config)
         var receivedError: Error?
@@ -173,10 +178,15 @@ class RouterTests: XCTestCase {
         XCTAssertNil(receivedError)
     }
 
-    func testDeleteRequestError() {
+    func testDeleteRequestError() throws {
         let jsonDict = ["message": "Not Found"]
-        let jsonString = String(data: try! JSONSerialization.data(withJSONObject: jsonDict, options: JSONSerialization.WritingOptions()), encoding: .utf8)
-        let session = RequestKitURLTestSession(expectedURL: "https://example.com/api/v1/some_route?access_token=1234&key1=value1%3A456&key2=value2", expectedHTTPMethod: "DELETE", response: jsonString, statusCode: 404)
+        let jsonString = try String(data: JSONSerialization.data(withJSONObject: jsonDict, options: JSONSerialization.WritingOptions()), encoding: .utf8)
+        let session = RequestKitURLTestSession(
+            expectedURL: "https://example.com/api/v1/some_route?access_token=1234&key1=value1%3A456&key2=value2",
+            expectedHTTPMethod: "DELETE",
+            response: jsonString,
+            statusCode: 404
+        )
         let config = TestConfiguration("1234", url: "https://example.com/api/v1/")
         let router = TestRouter.deleteRoute(config)
         var receivedError: Error?
@@ -219,7 +229,12 @@ class RouterTests: XCTestCase {
     #if compiler(>=5.5.2) && canImport(_Concurrency)
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func testDeleteRequestAsync() async throws {
-        let session = RequestKitURLTestSession(expectedURL: "https://example.com/api/v1/some_route?access_token=1234&key1=value1%3A456&key2=value2", expectedHTTPMethod: "DELETE", response: "", statusCode: 204)
+        let session = RequestKitURLTestSession(
+            expectedURL: "https://example.com/api/v1/some_route?access_token=1234&key1=value1%3A456&key2=value2",
+            expectedHTTPMethod: "DELETE",
+            response: "",
+            statusCode: 204
+        )
         let config = TestConfiguration("1234", url: "https://example.com/api/v1/")
         let router = TestRouter.deleteRoute(config)
         try await router.delete(session)


### PR DESCRIPTION
Router defined these HTTP methods but had no execution helpers — callers had to use workarounds via load() or JSONPostRouter.post(). Adds typed delete(), put<T>(), and patch<T>() with both callback and async/await variants, mirroring the existing post() shape.